### PR TITLE
refactor(proj): rename EsriExtent to Extent

### DIFF
--- a/src/proj.js
+++ b/src/proj.js
@@ -94,7 +94,7 @@ function localProjectExtent(extent, sr) {
 function projectEsriExtentBuilder(esriBundle) {
     return (extent, sr) => {
         const p = localProjectExtent(extent, sr);
-        return new esriBundle.EsriExtent(p.x0, p.y0, p.x1, p.y1, p.sr);
+        return new esriBundle.Extent(p.x0, p.y0, p.x1, p.y1, p.sr);
     };
 }
 


### PR DESCRIPTION
No EsriExtent in geoAPI; Extent is used instead.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/geoapi/72)
<!-- Reviewable:end -->
