### PR TITLE
feat(attribute): store field data

### DIFF
--- a/src/attribute.js
+++ b/src/attribute.js
@@ -10,6 +10,7 @@ const shared = require('./shared.js');
 function newLayerData() {
     return {
         features: [],
+        fields: [],
         oidField: '',
         oidIndex: {},
         layerId: '',
@@ -178,6 +179,7 @@ function loadFeatureAttribs(layerUrl, attribs, esriBundle) {
                 layerData.layerIdx = getLayerIndex(layerUrl);
 
                 if (serviceResult.type === 'Feature Layer') {
+                    layerData.fields = serviceResult.fields;
 
                     // find object id field
                     // NOTE cannot use arrow functions here due to bug
@@ -295,6 +297,7 @@ function processFeatureLayer(layer, options, esriBundle) {
             layerData.oidField = layer.objectIdField;
             layerData.layerId = layer.id;
             layerData.layerIdx = 0; // files have no index (no server), so we use value 0
+            layerData.fields = layer.fields;
 
             addLayerData(layerData, layer.graphics.map(elem => {
                 return { attributes: elem.attributes };

--- a/src/layer.js
+++ b/src/layer.js
@@ -36,7 +36,7 @@ function serverLayerIdentifyBuilder(esriBundle) {
     *   - layerIds: an array of integers specifying the layer indexes to be examined. Will override the current
     *     visible indexes in the layer parameter
     *   - returnGeometry: a boolean indicating if result geometery should be returned with results.  Defaults to false
-    *   - tolerance: an integer indicating how many screen pixels away from the mouse is valid for a hit.  Defaults to 2
+    *   - tolerance: an integer indicating how many screen pixels away from the mouse is valid for a hit.  Defaults to 5
     *
     * @method serverLayerIdentify
     * @param {Object} layer an ESRI dynamic layer object
@@ -63,7 +63,7 @@ function serverLayerIdentifyBuilder(esriBundle) {
             identParams.returnGeometry = opts.returnGeometry || false;
             identParams.layerOption = esriBundle.IdentifyParameters.LAYER_OPTION_ALL;
             identParams.spatialReference = opts.geometry.spatialReference;
-            identParams.tolerance = opts.tolerance || 2;
+            identParams.tolerance = opts.tolerance || 5;
 
             // TODO add support for identParams.layerDefinitions once attribute filtering is implemented
 


### PR DESCRIPTION
Store fields so we can use aliases and leverage data types if needed. 
Bonus enhance to identify default, as 5 is more forgiving than 2.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/geoapi/85)
<!-- Reviewable:end -->
