### PR TITLE
feat(geo): exposing graphics method in proj

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -45,6 +45,7 @@ module.exports = function (esriLoaderUrl, window) {
         ['esri/dijit/Scalebar', 'Scalebar'],
         ['esri/geometry/Extent', 'Extent'],
         ['esri/geometry/Point', 'Point'],
+        ['esri/graphicUtils/graphicsExtent', 'graphicsExtent'],
         ['esri/layers/ArcGISDynamicMapServiceLayer', 'ArcGISDynamicMapServiceLayer'],
         ['esri/layers/ArcGISImageServiceLayer', 'ArcGISImageServiceLayer'],
         ['esri/layers/ArcGISTiledMapServiceLayer', 'ArcGISTiledMapServiceLayer'],

--- a/src/proj.js
+++ b/src/proj.js
@@ -169,6 +169,7 @@ module.exports = function (esriBundle) {
         addProjection: proj4.defs, // straight passthrough at the moment, maybe add arg checking (two args)?
         getProjection: proj4.defs, // straight passthrough at the moment, maybe add arg checking (one arg)?
         esriServerProject: esriServiceBuilder(esriBundle),
+        graphicsExtent: esriBundle.graphicsExtent,
         isSpatialRefEqual,
         localProjectExtent,
         projectGeojson,


### PR DESCRIPTION
exposing [method](https://developers.arcgis.com/javascript/jsapi/esri.graphicsutils-amd.html#graphicsextent) that converts graphics into extent for use in zoomToGraphic in geoService.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/geoapi/91)
<!-- Reviewable:end -->
