### PR TITLE
feat(layer): error value on crashed predict

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "geoApi",
-  "version": "0.11.0",
+  "version": "0.12.0-1",
   "description": "",
   "main": "dist/geoapi.js",
   "dependencies": {},


### PR DESCRIPTION
Return type change to help user understand if layer predictor errored or was just confused.  In support of https://github.com/fgpv-vpgf/fgpv-vpgf/issues/611

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/geoapi/115)
<!-- Reviewable:end -->
