### PR TITLE
fix(layer): prevent utf8 overflow

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "terraformer": "~1.0.4",
     "terraformer-arcgis-parser": "~1.0.4",
     "terraformer-proj4js": "https://github.com/RAMP-PCAR/terraformer-proj4js.git#develop",
+    "text-encoding": "0.6.0",
     "vinyl-buffer": "~1.0.0",
     "vinyl-source-stream": "~1.1.0"
   },

--- a/src/layer.js
+++ b/src/layer.js
@@ -437,7 +437,8 @@ function predictLayerUrlBuilder(esriBundle) {
 */
 function arrayBufferToString(buffer) {
     // handles UTF8 encoding
-    return String.fromCharCode.apply(null, new Uint8Array(buffer));
+    return new TextDecoder('utf-8').decode(new Uint8Array(buffer));
+
 }
 
 /**


### PR DESCRIPTION
`fromCharCode` function would blow up if more than 65,500 bytes were fed to it.  Switched to `TextDecoder`.  In support of https://github.com/fgpv-vpgf/fgpv-vpgf/issues/611

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/geoapi/116)
<!-- Reviewable:end -->
