### PR TITLE
Source Projection Defaults

### DIFF
--- a/spec/layerSpec.js
+++ b/spec/layerSpec.js
@@ -1,0 +1,38 @@
+/* jshint jasmine: true */
+'use strict';
+const layerBuilder = require('../src/layer.js');
+
+describe('Layer', () => {
+    let layer;
+    const mockEsri = {
+        FeatureLayer: Object,
+        SpatialReference: Object
+    };
+    const mockGapi = {
+        proj: {
+            getProjection: () => Promise.resolve(null),
+            projectGeojson: () => { return; }
+        },
+        shared: { generateUUID: () => 'layer0' }
+    };
+    beforeEach(() => {
+        layer = layerBuilder(mockEsri, mockGapi);
+    });
+
+    it('should use 4326 as a default projection for GeoJSON', (done) => {
+        const geojsonTestPoint = require('./geojsonTestPoint.json');
+        spyOn(mockGapi.proj, 'projectGeojson');
+        const res = layer.makeGeoJsonLayer(geojsonTestPoint, {targetWkid: 54004});
+        res.then(x => {
+            const args = mockGapi.proj.projectGeojson.calls.mostRecent().args;
+            expect(args[1]).toEqual('EPSG:54004');
+            expect(args[2]).toEqual('EPSG:4326');
+            done();
+        })
+        .catch(e => {
+            fail(`Exception was thrown: ${e}`);
+            done();
+        });
+    });
+
+});

--- a/src/layer.js
+++ b/src/layer.js
@@ -701,7 +701,7 @@ function makeGeoJsonLayerBuilder(esriBundle, geoApi) {
 
         // TODO add documentation on why we only support layers with WKID (and not WKT).
         let targetWkid;
-        let srcProj;
+        let srcProj = 'EPSG:4326'; // 4326 is the default for GeoJSON with no projection defined
         let layerId;
         const layerDefinition = {
             objectIdField: 'OBJECTID',
@@ -764,6 +764,7 @@ function makeGeoJsonLayerBuilder(esriBundle, geoApi) {
 
         // make the layer
         const buildLayer = new Promise(resolve => {
+
             // project data and convert to esri json format
             // console.log('reprojecting ' + srcProj + ' -> EPSG:' + targetWkid);
             geoApi.proj.projectGeojson(geoJson, destProj, srcProj);
@@ -773,7 +774,6 @@ function makeGeoJsonLayerBuilder(esriBundle, geoApi) {
                 features: esriJson,
                 geometryType: layerDefinition.drawingInfo.geometryType
             };
-
             const layer = new esriBundle.FeatureLayer(
                 {
                     layerDefinition: layerDefinition,


### PR DESCRIPTION
Adds default source projection for GeoJSON.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/geoapi/118)
<!-- Reviewable:end -->
