### PR TITLE
Colour option for file layers

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "geoApi",
-  "version": "0.13.0-22",
+  "version": "0.13.0-23",
   "description": "",
   "main": "dist/geoapi.js",
   "dependencies": {},

--- a/src/index.js
+++ b/src/index.js
@@ -44,6 +44,7 @@ module.exports = function (esriLoaderUrl, window) {
     const esriDeps = [
         ['dojo/Deferred', 'Deferred'],
         ['dojo/query', 'dojoQuery'],
+        ['esri/Color', 'Color'],
         ['esri/config', 'esriConfig'],
         ['esri/dijit/Basemap', 'Basemap'],
         ['esri/dijit/BasemapGallery', 'BasemapGallery'],

--- a/src/layer.js
+++ b/src/layer.js
@@ -761,6 +761,7 @@ function makeGeoJsonLayerBuilder(esriBundle, geoApi) {
     *   - epsgLookup: a function that takes an EPSG code (string or number) and returns a promise of a proj4 style
     *     definition or null if not found
     *   - layerId: a string to use as the layerId
+    *   - colour: a hex string to define the symbol colour. e.g. '#33DD6A'
     *
     * @method makeGeoJsonLayer
     * @param {Object} geoJson An object following the GeoJSON specification, should be a FeatureCollection with
@@ -857,8 +858,9 @@ function makeGeoJsonLayerBuilder(esriBundle, geoApi) {
             // ＼(｀O´)／ manually setting SR because it will come out as 4326
             layer.spatialReference = new esriBundle.SpatialReference({ wkid: targetWkid });
 
-            // TODO : revisit if we actually need this anymore
-            // layer.renderer._RampRendererType = featureTypeToRenderer[geoJson.features[0].geometry.type];
+            if (opts.colour) {
+                layer.renderer.symbol.color = new esriBundle.Color(opts.colour);
+            }
 
             resolve(layer);
         });
@@ -884,6 +886,7 @@ function makeCsvLayerBuilder(esriBundle, geoApi) {
     *   - epsgLookup: a function that takes an EPSG code (string or number) and returns a promise of a proj4 style
     *     definition or null if not found
     *   - layerId: a string to use as the layerId
+    *   - colour: a hex string to define the symbol colour. e.g. '#33DD6A'
     * @param {string} csvData the CSV data to be processed
     * @param {object} opts options to be set for the parser
     * @returns {Promise} a promise resolving with a {FeatureLayer}
@@ -962,6 +965,7 @@ function makeShapeLayerBuilder(esriBundle, geoApi) {
     *   - epsgLookup: a function that takes an EPSG code (string or number) and returns a promise of a proj4 style
     *     definition or null if not found
     *   - layerId: a string to use as the layerId
+    *   - colour: a hex string to define the symbol colour. e.g. '#33DD6A'
     * @param {ArrayBuffer} shapeData an ArrayBuffer of the Shapefile in zip format
     * @param {object} opts options to be set for the parser
     * @returns {Promise} a promise resolving with a {FeatureLayer}

--- a/test/testFileLoad.html
+++ b/test/testFileLoad.html
@@ -62,7 +62,8 @@
             var opts = {
                 targetWkid: 102100,
                 sourceProjection: 'EPSG:4326', //'+proj=longlat +datum=WGS84 +no_defs',
-                epsgLookup: epsgLookup
+                epsgLookup: epsgLookup,
+                colour: '#ff3300'
             };
             var map = api.mapManager.Map(document.getElementById('map'), { basemap: 'terrain', zoom: 6, center: [-100, 50] });
 


### PR DESCRIPTION
Allows caller to set symbol colour for file layers

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/geoapi/133)
<!-- Reviewable:end -->
