### PR TITLE
File Symbology upgrades

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "geoApi",
-  "version": "0.13.0-23",
+  "version": "0.13.0-24",
   "description": "",
   "main": "dist/geoapi.js",
   "dependencies": {},

--- a/src/attribute.js
+++ b/src/attribute.js
@@ -272,11 +272,12 @@ function loadDataBatch(maxId, maxBatch, layerUrl, idField, attribs, callerDef, e
 /**
 * fetch attributes from an ESRI ArcGIS Server Feature Layer Service endpoint
 * @param {String} layerUrl an arcgis feature layer service endpoint
+* @param {Integer} featureIdx index of where the endpoint is. used for legend output
 * @param {String} attribs a comma separated list of attributes to download. '*' will download all
 * @param  {Object} esriBundle bundle of API classes
 * @return {Object} attributes in a packaged format for asynch access
 */
-function loadFeatureAttribs(layerUrl, attribs, esriBundle, geoApi) {
+function loadFeatureAttribs(layerUrl, featureIdx, attribs, esriBundle, geoApi) {
 
     const layerPackage = newLayerPackage(getLayerIndex(layerUrl), esriBundle);
 
@@ -322,7 +323,7 @@ function loadFeatureAttribs(layerUrl, attribs, esriBundle, geoApi) {
                     layerData.geometryType = serviceResult.geometryType;
                     layerData.minScale = serviceResult.minScale;
                     layerData.maxScale = serviceResult.maxScale;
-                    layerData.legend = geoApi.symbology.rendererToLegend(layerData.renderer);
+                    layerData.legend = geoApi.symbology.rendererToLegend(layerData.renderer, featureIdx);
 
                     geoApi.symbology.enhanceRenderer(layerData.renderer, layerData.legend);
 
@@ -396,7 +397,7 @@ function processFeatureLayer(layer, options, esriBundle, geoApi) {
         // check for skip flag
         if (!opts.skip) {
             // call loadFeatureAttribs with options if present
-            result.registerData(loadFeatureAttribs(layer.url, opts.attribs, esriBundle, geoApi));
+            result.registerData(loadFeatureAttribs(layer.url, idx, opts.attribs, esriBundle, geoApi));
         }
     } else {
         // feature layer was loaded from a file.
@@ -411,7 +412,7 @@ function processFeatureLayer(layer, options, esriBundle, geoApi) {
         })));
 
         const renderer = layer.renderer.toJson();
-        const legend = geoApi.symbology.rendererToLegend(renderer);
+        const legend = geoApi.symbology.rendererToLegend(renderer, 0);
         geoApi.symbology.enhanceRenderer(renderer, legend);
 
         // TODO revisit the geometry type. ideally, fix our GeoJSON to Feature to populate the property
@@ -490,7 +491,7 @@ function processDynamicLayer(layer, options, esriBundle, geoApi) {
 
             if (!opts.skip) {
                 // load the features, store promise in array
-                result.registerData(loadFeatureAttribs(layer.url + '/' + idx.toString(),
+                result.registerData(loadFeatureAttribs(layer.url + '/' + idx.toString(), idx,
                     opts.attribs, esriBundle, geoApi));
             }
 

--- a/src/symbology.js
+++ b/src/symbology.js
@@ -275,31 +275,36 @@ function applyFill(symbol, svg) {
 * @param  {Object} svg contains info on our SVG object (see newSVG). object is modified by the function
 */
 function applyLine(lineSymbol, svg) {
-    const stroke = lineSymbol.style === 'esriSLSNull' ? 'none' : colourToRgb(lineSymbol.color);
+    if (lineSymbol) {
+        const stroke = lineSymbol.style === 'esriSLSNull' ? 'none' : colourToRgb(lineSymbol.color);
 
-    svg.addProp('stroke', stroke);
-    svg.addProp('stroke-opacity', colourToOpacity(lineSymbol.color));
-    svg.addProp('stroke-width', lineSymbol.width.toString());
-    svg.addProp('stroke-linecap', 'butt'); // huh huh
-    svg.addProp('stroke-linejoin', 'miter');
-    svg.addProp('stroke-miterlimit', '4');
+        svg.addProp('stroke', stroke);
+        svg.addProp('stroke-opacity', colourToOpacity(lineSymbol.color));
+        svg.addProp('stroke-width', lineSymbol.width.toString());
+        svg.addProp('stroke-linecap', 'butt'); // huh huh
+        svg.addProp('stroke-linejoin', 'miter');
+        svg.addProp('stroke-miterlimit', '4');
 
-    const dashMap = {
-        esriSLSSolid: 'none',
-        esriSLSDash: '5.333,4',
-        esriSLSDashDot: '5.333,4,1.333,4',
-        esriSLSLongDashDotDot: '10.666,4,1.333,4,1.333,4',
-        esriSLSDot: '1.333,4',
-        esriSLSLongDash: '10.666,4',
-        esriSLSLongDashDot: '10.666,4,1.333,4',
-        esriSLSShortDash: '5.333,1.333',
-        esriSLSShortDashDot: '5.333,1.333,1.333,1.333',
-        esriSLSShortDashDotDot: '5.333,1.333,1.333,1.333,1.333,1.333',
-        esriSLSShortDot: '1.333,1.333',
-        esriSLSNull: 'none'
-    };
+        const dashMap = {
+            esriSLSSolid: 'none',
+            esriSLSDash: '5.333,4',
+            esriSLSDashDot: '5.333,4,1.333,4',
+            esriSLSLongDashDotDot: '10.666,4,1.333,4,1.333,4',
+            esriSLSDot: '1.333,4',
+            esriSLSLongDash: '10.666,4',
+            esriSLSLongDashDot: '10.666,4,1.333,4',
+            esriSLSShortDash: '5.333,1.333',
+            esriSLSShortDashDot: '5.333,1.333,1.333,1.333',
+            esriSLSShortDashDotDot: '5.333,1.333,1.333,1.333,1.333,1.333',
+            esriSLSShortDot: '1.333,1.333',
+            esriSLSNull: 'none'
+        };
 
-    svg.addProp('stroke-dasharray', dashMap[lineSymbol.style]);
+        svg.addProp('stroke-dasharray', dashMap[lineSymbol.style]);
+    } else {
+        // odd case where a symbol is missing an outline, so an undefined gets passed in
+        svg.addProp('stroke', 'none');
+    }
 
 }
 

--- a/test/testFileLoad.html
+++ b/test/testFileLoad.html
@@ -71,6 +71,12 @@
                 map.addLayer(happyLayer);
 
                 console.log(happyLayer);
+
+                var attbundle = api.attribs.loadLayerAttribs(happyLayer);
+                attbundle["0"].layerData.then(ld => {
+                    console.log('happy layer data', ld);
+                });
+
             });
 
 
@@ -88,6 +94,11 @@
             csvPromise.then(function(csvLayer){
                 map.addLayer(csvLayer);
                 console.log(csvLayer);
+
+                var attbundle2 = api.attribs.loadLayerAttribs(csvLayer);
+                attbundle2["0"].layerData.then(ld => {
+                    console.log('csv layer data', ld);
+                });
             });
 
             var csvPeeker = api.layer.csvPeek(csvData, ',');


### PR DESCRIPTION
Handle missing outlines on symbols (was occurring in CSV layers).
Add correct value to `layerId` in renderer-generated legends, to support icons showing in layer selector

Closes (in part) https://github.com/fgpv-vpgf/fgpv-vpgf/issues/867

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/geoapi/134)
<!-- Reviewable:end -->
