### PR TITLE
Class breaks renderer fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "geoApi",
-  "version": "1.0.1-4",
+  "version": "1.0.1-5",
   "description": "",
   "main": "dist/geoapi.js",
   "dependencies": {},

--- a/src/symbology.js
+++ b/src/symbology.js
@@ -121,7 +121,7 @@ function searchRenderer(attributes, renderer) {
 
         case CLASS_BREAKS:
 
-            const gVal = attributes[renderer.field];
+            const gVal = parseFloat(attributes[renderer.field]);
             const lower = renderer.minValue;
 
             imageUrl = renderer.defaultImageUrl;
@@ -131,11 +131,12 @@ function searchRenderer(attributes, renderer) {
             if (gVal < lower) { break; }
 
             // array of minimum values of the ranges in the renderer
-            let minSplits = renderer.classBreakInfos.map(cbi => cbi.maxValue);
+            let minSplits = renderer.classBreakInfos.map(cbi => cbi.classMaxValue);
             minSplits.splice(0, 0, lower - 1); // put lower-1 at the start of the array and shift all other entries by 1
 
             // attempt to find the range our gVal belongs in
-            const cbi = renderer.classBreakInfos.find((cbi, index) => gVal > minSplits[index] && gVal <= cbi.maxValue);
+            const cbi = renderer.classBreakInfos.find((cbi, index) => gVal > minSplits[index] &&
+                gVal <= cbi.classMaxValue);
             if (!cbi) { break; } // outside of range on the high end
             imageUrl = cbi.imageUrl;
             symbol = cbi.symbol;

--- a/test/testSymbols.html
+++ b/test/testSymbols.html
@@ -13,7 +13,7 @@
     <script src='../dist/geoapi.min.js'></script>
     <script>
         geoapi('http://js.arcgis.com/3.14/', window).then(function (api) {
-        var layer = new api.layer.FeatureLayer('http://maps-cartes.ec.gc.ca/ArcGIS/rest/services/CommonGIS_AuxMerc/MapServer/1');
+        var layer = new api.layer.FeatureLayer('http://sncr01wbingsdv1.ncr.int.ec.gc.ca/arcgis/rest/services/CESI/CESI_Air_SO2/MapServer/1');
 
         layer.on('load', function(evt) {
             console.log('EEEEEEEEEEEEEEEEEEEEEEEEEEEEEE LOADED', layer.renderer);
@@ -23,7 +23,7 @@
             var fData = api.attribs.loadLayerAttribs(layer);
             console.log('GGGGGGGGGGGGGGGGGG fData', fData);
 
-            var oid = 7;
+            var oid = 22795;
             console.log('FFFFFFFFFFFFFFFFFFFFFFFFFFF', fData[1]);
             fData[1].layerData.then(lData => {
                 console.log('IIIIIIIIIIIIIIII renderer', lData.renderer);


### PR DESCRIPTION
Allow class breaks symbol search to work with target values in string format.
Also corrects a mistake where code was looking for a client-side object property on a server-side object.

Closes https://github.com/fgpv-vpgf/fgpv-vpgf/issues/948

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/geoapi/143)
<!-- Reviewable:end -->
