### PR TITLE
Use proper oids for files

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "geoApi",
-  "version": "1.0.2",
+  "version": "1.0.3-8",
   "description": "",
   "main": "dist/geoapi.js",
   "dependencies": {},

--- a/src/layer.js
+++ b/src/layer.js
@@ -717,9 +717,10 @@ function assignIds(geoJson) {
     }
 
     // for every feature, if it does not have an id property, add it.
+    // 0 is not a valid object id
     geoJson.features.forEach(function (val, idx) {
         if (typeof val.id === 'undefined') {
-            val.id = idx;
+            val.id = idx + 1;
         }
     });
 }


### PR DESCRIPTION
Latest update to terraformer no longer accepts 0 as an object id. 

Closes https://github.com/fgpv-vpgf/fgpv-vpgf/issues/1103

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/geoapi/147)
<!-- Reviewable:end -->
