### PR TITLE
LOD scale search

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "geoApi",
-  "version": "1.0.5",
+  "version": "1.0.6-1",
   "description": "",
   "main": "dist/geoapi.js",
   "dependencies": {

--- a/src/mapManager.js
+++ b/src/mapManager.js
@@ -29,7 +29,8 @@ module.exports = function (esriBundle) {
         getExtentFromJson,
         setupMap,
         setProxy,
-        mapDefault
+        mapDefault,
+        findClosestLOD
     };
 
     let basemapCtrl;
@@ -180,6 +181,22 @@ module.exports = function (esriBundle) {
         return esriBundle.Extent({ xmin: extentJson.xmin, ymin: extentJson.ymin,
             xmax: extentJson.xmax, ymax: extentJson.ymax,
             spatialReference: { wkid: extentJson.spatialReference.wkid } });
+    }
+
+    /**
+     * @ngdoc method
+     * @name findClosestLOD
+     * @memberof mapManager
+     * Finds the level of detail closest to the provided scale.
+     *
+     * @param  {Array} lods     list of levels of detail objects
+     * @param  {Number} scale   scale value to search for in the levels of detail
+     * @return {Object} the level of detail object closest to the scale
+     */
+    function findClosestLOD(lods, scale) {
+        const diffs = lods.map(lod => Math.abs(lod.scale - scale));
+        const lodIdx = diffs.indexOf(Math.min(...diffs));
+        return lods[lodIdx];
     }
 
     return mapManager;

--- a/test/test.html
+++ b/test/test.html
@@ -9,7 +9,7 @@
 </head>
 <body>
     <div id="map"></div>
-    <script src="../dist/geoapi.min.js"></script>
+    <script src="../dist/geoapi.js"></script>
     <script>
         var esriMap;
         geoapi('http://js.arcgis.com/3.14/', window).then(function (api) {

--- a/test/testAttribute.html
+++ b/test/testAttribute.html
@@ -9,7 +9,7 @@
 </head>
 <body>
     <p id="mess" />
-    <script src="../dist/geoapi.min.js"></script>
+    <script src="../dist/geoapi.js"></script>
     <script>
         geoapi('http://js.arcgis.com/3.14/', window).then(function (api) {
 

--- a/test/testBasemap.html
+++ b/test/testBasemap.html
@@ -10,7 +10,7 @@
 <body>
     <div id="basemapG" style="height:100px; width:100px;" ></div>
     <div id="map" style="height:90%; width: 100%;"></div>
-    <script src="../dist/geoapi.min.js"></script>
+    <script src="../dist/geoapi.js"></script>
     <script>
         geoapi('http://js.arcgis.com/3.14/', window).then(function (api) {
             var map = api.mapManager.Map(document.getElementById('map'), { basemap: 'topo', zoom: 6, center: [-100, 50] });

--- a/test/testDynamicGeo.html
+++ b/test/testDynamicGeo.html
@@ -9,7 +9,7 @@
 </head>
 <body>
     <p id="mess" />
-    <script src="../dist/geoapi.min.js"></script>
+    <script src="../dist/geoapi.js"></script>
     <script>
         geoapi('http://js.arcgis.com/3.14/', window).then(function (api) {
 

--- a/test/testEsri.html
+++ b/test/testEsri.html
@@ -9,7 +9,7 @@
 </head>
 <body>
     <p id="mess" />
-    <script src="../dist/geoapi.min.js"></script>
+    <script src="../dist/geoapi.js"></script>
     <script>
         geoapi('http://js.arcgis.com/3.14/', window).then(function (api) {
             var sr = new api.proj.SpatialReference({ wkid: 102100 });

--- a/test/testEvents.html
+++ b/test/testEvents.html
@@ -10,7 +10,7 @@
 <body>
     <div id="map" style="height:90%; width: 100%;"></div>
     <p id="mess" />
-    <script src="../dist/geoapi.min.js"></script>
+    <script src="../dist/geoapi.js"></script>
     <script>
         geoapi('http://js.arcgis.com/3.14/', window).then(function (api) {
             var map = api.mapManager.Map(document.getElementById('map'), { basemap: 'topo', zoom: 6, center: [-100, 50] });

--- a/test/testFileLoad.html
+++ b/test/testFileLoad.html
@@ -9,7 +9,7 @@
     </style>
 </head>
 <body>
-    <script src="../dist/geoapi.min.js"></script>
+    <script src="../dist/geoapi.js"></script>
     <script>
         geoapi('http://js.arcgis.com/3.14/', window).then(function (api) {
 

--- a/test/testFileValid.html
+++ b/test/testFileValid.html
@@ -10,7 +10,7 @@
 <body>
     <div id="map" style="height:90%; width: 100%;"></div>
     <p id="mess" />
-    <script src="../dist/geoapi.min.js"></script>
+    <script src="../dist/geoapi.js"></script>
     <script>
         geoapi('http://js.arcgis.com/3.14/', window).then(function (api) {
 

--- a/test/testGeomProj.html
+++ b/test/testGeomProj.html
@@ -18,7 +18,7 @@
     </style>
 </head>
 <body>
-    <script src="../dist/geoapi.min.js"></script>
+    <script src="../dist/geoapi.js"></script>
     <script>
         geoapi('http://js.arcgis.com/3.14/', window).then(function (api) {
             

--- a/test/testHilight.html
+++ b/test/testHilight.html
@@ -18,7 +18,7 @@
     </style>
 </head>
 <body>
-    <script src="../dist/geoapi.min.js"></script>
+    <script src="../dist/geoapi.js"></script>
     <script>
         geoapi('http://js.arcgis.com/3.14/', window).then(function (api) {
             

--- a/test/testIdent.html
+++ b/test/testIdent.html
@@ -9,7 +9,7 @@
     </style>
 </head>
 <body>
-    <script src="../dist/geoapi.min.js"></script>
+    <script src="../dist/geoapi.js"></script>
     <script>
         geoapi('http://js.arcgis.com/3.14/', window).then(function (api) {
 

--- a/test/testQuery.html
+++ b/test/testQuery.html
@@ -9,7 +9,7 @@
 </head>
 <body>
     <p id="mess" />
-    <script src="../dist/geoapi.min.js"></script>
+    <script src="../dist/geoapi.js"></script>
     <script>
         geoapi('http://js.arcgis.com/3.14/', window).then(function (api) {
 

--- a/test/testScalebar.html
+++ b/test/testScalebar.html
@@ -12,7 +12,7 @@
 <body class="claro">
     <div id="basemapG" style="height:100px; width:100px;" ></div>
     <div id="map" style="height:100%; width: 100%; margin: 0; overflow:hidden;"></div>
-    <script src="../dist/geoapi.min.js"></script>
+    <script src="../dist/geoapi.js"></script>
     <script>
         geoapi('http://js.arcgis.com/3.14/', window).then(function (api) {
             var map = api.mapManager.Map(document.getElementById('map'), { basemap: 'topo', zoom: 6, center: [-100, 50] });

--- a/test/testSymbols.html
+++ b/test/testSymbols.html
@@ -10,7 +10,7 @@
 <body>
     <div id='map' style='height:90%; width: 100%;'></div>
     <p id='mess' />
-    <script src='../dist/geoapi.min.js'></script>
+    <script src='../dist/geoapi.js'></script>
     <script>
         geoapi('http://js.arcgis.com/3.14/', window).then(function (api) {
         var layer = new api.layer.FeatureLayer('http://sncr01wbingsdv1.ncr.int.ec.gc.ca/arcgis/rest/services/CESI/CESI_Air_SO2/MapServer/1');

--- a/test/testUrl.html
+++ b/test/testUrl.html
@@ -10,7 +10,7 @@
 <body>
     <div id="map" style="height:90%; width: 100%;"></div>
     <p id="mess" />
-    <script src="../dist/geoapi.min.js"></script>
+    <script src="../dist/geoapi.js"></script>
     <script>
         geoapi('http://js.arcgis.com/3.14/', window).then(function (api) {
 

--- a/test/testZoomLevel.html
+++ b/test/testZoomLevel.html
@@ -10,10 +10,10 @@
 <body>
     <div id='map' style='height:90%; width: 100%;'></div>
     <p id='mess' />
-    <script src='../dist/geoapi.min.js'></script>
+    <script src='../dist/geoapi.js'></script>
     <script>
         geoapi('http://js.arcgis.com/3.14/', window).then(function (api) {
-            var layer = new api.layer.FeatureLayer('http://maps-cartes.ec.gc.ca/ArcGIS/rest/services/CESI_Air_Ozone/MapServer/2');
+            var layer = new api.layer.FeatureLayer('http://maps-cartes.ec.gc.ca/arcgis/rest/services/CESI/CESI_Air_Ozone/MapServer/2');
 
             layer.on('load', function(evt) {
                 const lods =
@@ -42,6 +42,9 @@
                 console.log('fffffffffffffffff', layer.maxScale);
                 var zoomLv = api.symbology.getZoomLevel(lods, layer.maxScale);
                 console.log(zoomLv);
+
+                var myLevel = api.mapManager.findClosestLOD(lods, 300000);
+                console.log('THIS IS MY SEARCHED LOD', myLevel);
             });
         });
     </script>


### PR DESCRIPTION
Moved `findClosestLOD` function from application geo module to the geoApi.  Function searches an LOD array to find LOD closest to the provided scale.

Also updated test page references to not use the minified library, as it is not generated unless you add extra flags to the serve command

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/geoapi/157)
<!-- Reviewable:end -->
