### PR TITLE
feat(export): return local and server based images as separate promises

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "geoApi",
-  "version": "1.0.6",
+  "version": "1.0.7-1",
   "description": "",
   "main": "dist/geoapi.js",
   "dependencies": {

--- a/src/mapPrint.js
+++ b/src/mapPrint.js
@@ -11,7 +11,6 @@ const canvg = require('canvg-origin');
   *
   * This module exports an object with the following functions
   * - `printMap`
-  * - `exportMap`
   */
 
 /**

--- a/src/mapPrint.js
+++ b/src/mapPrint.js
@@ -127,6 +127,7 @@ function generateLocalCanvas(map) {
         // parse the svg
         // convert svg text to canvas and stuff it into localCanvas canvas dom node
         canvg(localCanvas, svgtext, {
+            useCORS: true,
             renderCallback: () =>
                 resolve(localCanvas)
         });
@@ -139,13 +140,14 @@ function generateLocalCanvas(map) {
 * Convert an image to a canvas element
 *
 * @param {String} url image url to convert (result from the esri print task)
-* @return {Promise} convertion promise resolving into a canvas of the image
+* @return {Promise} conversion promise resolving into a canvas of the image
 */
 function convertImageToCanvas(url) {
     const canvas = document.createElement('canvas');
     const image = document.createElement('img'); // create image node
+    image.crossOrigin = 'Anonymous'; // configure the CORS request
 
-    const convertionPromise = new Promise((resolve, reject) => {
+    const conversionPromise = new Promise((resolve, reject) => {
         image.addEventListener('load', () => {
 
             canvas.width = image.width;
@@ -162,7 +164,7 @@ function convertImageToCanvas(url) {
     // set image source to the one generated from the print task
     image.src = url;
 
-    return convertionPromise;
+    return conversionPromise;
 }
 
 /**
@@ -171,7 +173,7 @@ function convertImageToCanvas(url) {
 *
 * @param {Object} esriBundle bundle of API classes
 * @param {Object} geoApi geoApi to determine if we are in debug mode
-* @return {Object} with two promises - local and server canvas; each promise resolves with a corresponding canvas
+* @return {Object} with two promises - local and server canvas; each promise resolves with a corresponding canvas; each promise can error separately if the canvas cannot be generated returning whatever error message was supplied; it's responsibility of the caller to handle errors appropriately
 */
 function printMap(esriBundle, geoApi) {
 

--- a/src/mapPrint.js
+++ b/src/mapPrint.js
@@ -1,4 +1,7 @@
 'use strict';
+
+// ugly way to add rgbcolor to global scope so it can be used by canvg inside the viewer; this is done because canvg uses UMD loader and has rgbcolor as internal dependency; there is no elegant way around it; another approach would be to clone canvg and change its loader;
+window.RGBColor = require('rgbcolor');
 const canvg = require('canvg-origin');
 
 /**

--- a/src/mapPrint.js
+++ b/src/mapPrint.js
@@ -14,6 +14,8 @@ const canvg = require('canvg-origin');
   *
   * This module exports an object with the following functions
   * - `printMap`
+  *
+  * NOTE: unit tests might be difficult to implement as DOM is required...
   */
 
 /**
@@ -126,14 +128,22 @@ function generateLocalCanvas(map) {
     const svgtext = document.getElementById(`esri\.Map_${map.id.split('_')[1]}_gc`).outerHTML;
     const localCanvas = document.createElement('canvas'); // create canvas element
 
-    const generationPromise = new Promise(resolve => {
+    const generationPromise = new Promise((resolve, reject) => {
         // parse the svg
         // convert svg text to canvas and stuff it into localCanvas canvas dom node
-        canvg(localCanvas, svgtext, {
-            useCORS: true,
-            renderCallback: () =>
-                resolve(localCanvas)
-        });
+
+        // wrapping in try/catch since canvg has NO error handling; not sure what errors this can catch though
+        try {
+            canvg(localCanvas, svgtext, {
+                useCORS: true,
+                ignoreAnimation: true,
+                ignoreMouse: true,
+                renderCallback: () =>
+                    resolve(localCanvas)
+            });
+        } catch (error) {
+            reject(error);
+        }
     });
 
     return generationPromise;

--- a/test/testMapPrint.html
+++ b/test/testMapPrint.html
@@ -105,7 +105,29 @@
                     url: geo,
                     format: 'png32',
                 }
-                api.mapPrint.print(map2,
+
+                let resultCanvas = document.getElementById('result-canvas-2');
+
+                const printTask = api.mapPrint.print(map2, options);
+                printTask.localPromise.then(canvas => {
+                    document.getElementsByTagName('body')[0].appendChild(canvas);
+                    resultCanvas
+                        .getContext('2d')
+                        .drawImage(canvas, 0, 0);
+                });
+                printTask.serverPromise.then(canvas => {
+                    document.getElementsByTagName('body')[0].appendChild(canvas);
+                    resultCanvas
+                        .getContext('2d')
+                        .drawImage(canvas, 0, 0);
+                });
+
+                Promise.all([printTask.localPromise, printTask.serverPromise]).then(result => {
+                    console.log('canvas created map 2!');
+
+                }).catch(error => console.log('canvas not created map 2!', error));
+
+                /*api.mapPrint.print(map2,
                                     options).then(canvas => {
                     if (canvas.complete) {
                         let canvasResult = document.getElementById('result-canvas-2');
@@ -116,7 +138,7 @@
                     } else {
                         console.log(`canvas not created map 2! ${canvas.error}`);
                     }
-                });
+                });*/
             });
         });
 


### PR DESCRIPTION
also, render an image for __all__ vector layers locally on the client since it's faster

Relates fgpv-vpgf/fgpv-vpgf#1267

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/geoapi/161)
<!-- Reviewable:end -->
