### PR TITLE
1279 fix wms tainted canvas laundering

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "geoApi",
-  "version": "1.0.7-1",
+  "version": "1.0.7-2",
   "description": "",
   "main": "dist/geoapi.js",
   "dependencies": {

--- a/src/mapPrint.js
+++ b/src/mapPrint.js
@@ -3,6 +3,7 @@
 // ugly way to add rgbcolor to global scope so it can be used by canvg inside the viewer; this is done because canvg uses UMD loader and has rgbcolor as internal dependency; there is no elegant way around it; another approach would be to clone canvg and change its loader;
 window.RGBColor = require('rgbcolor');
 const canvg = require('canvg-origin');
+const shared = require('./shared.js')();
 
 /**
   * @ngdoc module
@@ -79,7 +80,7 @@ function generateServerImage(esriBundle, geoApi, map, options) {
         // execute the print task
         printTask.execute(printParams,
             response =>
-                resolve(convertImageToCanvas(response.url)),
+                resolve(shared.convertImageToCanvas(response.url)),
             error =>
                 reject(error)
         );
@@ -147,37 +148,6 @@ function generateLocalCanvas(map) {
     });
 
     return generationPromise;
-}
-
-/**
-* Convert an image to a canvas element
-*
-* @param {String} url image url to convert (result from the esri print task)
-* @return {Promise} conversion promise resolving into a canvas of the image
-*/
-function convertImageToCanvas(url) {
-    const canvas = document.createElement('canvas');
-    const image = document.createElement('img'); // create image node
-    image.crossOrigin = 'Anonymous'; // configure the CORS request
-
-    const conversionPromise = new Promise((resolve, reject) => {
-        image.addEventListener('load', () => {
-
-            canvas.width = image.width;
-            canvas.height = image.height;
-            canvas.getContext('2d').drawImage(image, 0, 0); // draw image onto a canvas
-
-            // return canvas
-            resolve(canvas);
-        });
-        image.addEventListener('error', error =>
-            reject(error));
-    });
-
-    // set image source to the one generated from the print task
-    image.src = url;
-
-    return conversionPromise;
 }
 
 /**

--- a/src/shared.js
+++ b/src/shared.js
@@ -1,6 +1,9 @@
 // Common functions for use across other geoApi modules
 'use strict';
 
+// store a reusable canvas
+let sharedCanvas;
+
 function getLayerTypeBuilder(esriBundle) {
     /**
     * Will return a string indicating the type of layer a layer object is.
@@ -44,7 +47,75 @@ function generateUUID() {
     });
 }
 
+/**
+* Convert an image to a canvas element
+*
+* @param {String} url image url to convert (result from the esri print task)
+* @param {Boolean} crossOrigin [optional] default to true; when set, tries to fetch an image with crossOrigin = anonymous
+* @return {Promise} conversion promise resolving into a canvas of the image
+*/
+function convertImageToCanvas(url, crossOrigin = true) {
+    if (!sharedCanvas) {
+        sharedCanvas = document.createElement('canvas');
+    }
+
+    const image = document.createElement('img'); // create image node
+
+    if (crossOrigin) {
+        image.crossOrigin = 'Anonymous'; // configure the CORS request
+    }
+
+    const conversionPromise = new Promise((resolve, reject) => {
+        image.addEventListener('load', () => {
+
+            sharedCanvas.width = image.width; // changing canvas size will clear all previous content
+            sharedCanvas.height = image.height;
+            sharedCanvas.getContext('2d').drawImage(image, 0, 0); // draw image onto a canvas
+
+            // return canvas
+            resolve(sharedCanvas);
+        });
+        image.addEventListener('error', error =>
+            reject(error));
+    });
+
+    // set image source to the one generated from the print task
+    image.src = url;
+
+    return conversionPromise;
+}
+
+/**
+ * Loads an image (as crossing) and converts it to dataURL. If a supplied imageUri is already a dataURL, just return it.
+ * If an image fails to load with the crossing attribute, return the original imageUri
+ *
+ * @function convertImagetoDataURL
+ * @param {String} imageUri url of the image to load and convert
+ * @return {Promise} promise resolving with the dataURL of the image
+ */
+function convertImagetoDataURL(imageUri) {
+    // this is already a dataUrl, just return
+    if (imageUri.startsWith('data')) {
+        console.log('ImageUri is already a data url');
+        return Promise.resolve(imageUri);
+    }
+
+    const loadingPromise = convertImageToCanvas(imageUri)
+        .then(canvas => {
+            console.log('Converting image to dataURL');
+            return canvas.toDataURL('image/png');
+        })
+        .catch(error => {
+            console.error('Failed to load crossorigin image', imageUri, error);
+            return imageUri;
+        });
+
+    return loadingPromise;
+}
+
 module.exports = esriBundle => ({
     getLayerType: getLayerTypeBuilder(esriBundle),
-    generateUUID
+    generateUUID,
+    convertImageToCanvas,
+    convertImagetoDataURL
 });

--- a/test/testMapPrint.html
+++ b/test/testMapPrint.html
@@ -20,7 +20,7 @@
     <script src="../dist/geoapi.js"></script>
     <script>
         geoapi('http://js.arcgis.com/3.14/', window).then(api => {
-
+            api.mapManager.setProxy('http://cp.zz9.ca/index');
             // set debug
             api.debug(true);
 
@@ -60,6 +60,10 @@
             var geoFeatLayerSmall2 = new api.layer.FeatureLayer('http://geoappext.nrcan.gc.ca/arcgis/rest/services/FGP/canadian_airports_with_air_navigation_services_en/MapServer/0');
             map1.addLayer(geoFeatLayerSmall1);
             map2.addLayer(geoFeatLayerSmall2);
+
+            var wmsLayerVisible = ['railway.track', 'railway.station'];
+            var wmsLayer = new api.layer.ogc.WmsLayer('http://maps.geogratis.gc.ca/wms/railway_en', {visibleLayers:wmsLayerVisible});
+            map2.addLayer(wmsLayer);
 
             // fgp layer (3)
             var fgpLayer = new api.layer.ArcGISDynamicMapServiceLayer('http://webservices-staging.maps.canada.ca/arcgis/rest/services/NRCAN/PEI_RRN/MapServer');

--- a/test/testSymbLeg.html
+++ b/test/testSymbLeg.html
@@ -435,7 +435,7 @@
                             "style": "esriSLSSolid"
                         },
                         "type": "esriPFS",
-                        "url": "http://www.free.designquery.com/01/bg0245.jpg",
+                        "url": "http://ak2.imgaft.com/images/new_logo_gd3.jpg",
                         "width": 15,
                         "height": 15,
                         "xoffset": 0,


### PR DESCRIPTION
Closes fgpv-vpgf/fgpv-vpgf#1279

Out of three WMS layers in `index-one` page, only "Groundwater Information Network" layer is not CORS-enabled and its legend images will taint the export canvas preventing it from saving directly. Legends for "Railways" and "Grounwater" WMS layers can be saved directly as part of the map export image.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/geoapi/164)
<!-- Reviewable:end -->
