### PR TITLE
feat(geoApi): add management of null graphickey value

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "geoApi",
-  "version": "1.0.7-2",
+  "version": "1.0.7-3",
   "description": "",
   "main": "dist/geoapi.js",
   "dependencies": {

--- a/src/symbology.js
+++ b/src/symbology.js
@@ -102,7 +102,8 @@ function searchRenderer(attributes, renderer) {
         case UNIQUE_VALUE:
 
             // make a key value for the graphic in question, using comma-space delimiter if multiple fields
-            let graphicKey = attributes[renderer.field1];
+            // put an empty string when key value is null
+            let graphicKey = attributes[renderer.field1] === null ? '' : attributes[renderer.field1];
 
             // all key values are stored as strings.  if the attribute is in a numeric column, we must convert it to a string to ensure the === operator still works.
             if (typeof graphicKey !== 'string') {


### PR DESCRIPTION
Before: datatable cannot load when graphicKey value is set to null
After: set graphickey to an empty string when graphicKey is null so the
datatable can load properly.

Closes #1184

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/geoapi/165)
<!-- Reviewable:end -->
