### PR TITLE
feat(export): can specify the export image size

### DIFF
--- a/src/mapPrint.js
+++ b/src/mapPrint.js
@@ -59,7 +59,7 @@ function generateServerImage(esriBundle, geoApi, map, options) {
     // define whether the printed map should preserve map scale or map extent.
     // if true, the printed map will use the outScale property or default to the scale of the input map.
     // if false, the printed map will use the same extent as the input map and thus scale might change.
-    // we always use false because the output image needs to be of the same extend as the size might be different
+    // we always use false because the output image needs to be of the same extent as the size might be different
     // we fit the image later because trying to fit the image with canvg when we add user added
     // layer is tricky!
     printTemplate.preserveScale = false;
@@ -123,7 +123,9 @@ function showLayers(layers) {
 * Create a canvas from the user added layers (svg tag)
 *
 * @param {Object} map esri map object
-* @param {Object} options [optional = null] width and height values; needed to get canvas of a size different from default
+* @param {Object} options [optional = null] { width, height } values; needed to get canvas of a size different from default
+*                           width {Number}
+*                           height {Number}
 * @param {Object} canvas [optional = null] canvas to draw the image upon; if not supplied, a new canvas will be made
 * @return {Promise} resolving when the canvas have been created
 *                           resolve with a canvas element with user added layer on it
@@ -177,9 +179,19 @@ function generateLocalCanvas(map, options = null, canvas = null) {
      * @function resizeSVGElement
      * @private
      * @param {Object} element target svg element to be resized
-     * @param {Object} targetSize target width and height;
-     * @param {Object} targetViewbox [optiopnal = null] target viewbox width and height; if not specified, the original size will be used as the viewbox
-     * @return {Object} returns original size and viewbox of the svg element; can be used to restore the element to its original state
+     * @param {Object} targetSize object with target sizes in the form of { width, height }
+     *                           width {Number}
+     *                           height {Number}
+     * @param {Object} targetViewbox [optional = null] target viewbox sizes in the form of { width, height }; if not specified, the original size will be used as the viewbox
+     *                           width {Number}
+     *                           height {Number}
+     * @return {Object} returns original size and viewbox of the svg element in the form of { originalSize: { width, height }, originalViewbox: { width, height } }; can be used to restore the element to its original state
+     *                          originalSize:
+     *                              width {Number}
+     *                              height {Number}
+     *                          originalViewbox:
+     *                              width {Number}
+     *                              height {Number}
      */
     function resizeSVGElement(element, targetSize, targetViewbox = null) {
         const originalSize = {


### PR DESCRIPTION
## Description
Note: scale preservation is turned off, otherwise the extent chagnes
depending on the image size  Relates fgpv-vpgf/fgpv-vpgf#1258

No demo for this yet.

## Testing
Eyeballing tests done. Unit tests are hard due to the need of a DOM.

## Documentation
Source comments updated.

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [x] commits messages follow the guidelines
- [x] code passes unit tests
- [ ] release notes have been updated - release notes will be updated when a PR on the viewer is merged
- [x] PR targets the correct release version

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/geoapi/170)
<!-- Reviewable:end -->
