### PR TITLE
fix(export): set viewbox on svg layers if absent

### DIFF
--- a/src/mapPrint.js
+++ b/src/mapPrint.js
@@ -194,10 +194,17 @@ function generateLocalCanvas(map, options = null, canvas = null) {
      *                              height {Number}
      */
     function resizeSVGElement(element, targetSize, targetViewbox = null) {
+
         const originalSize = {
             width: element.width.baseVal.value,
             height: element.height.baseVal.value
         };
+
+        // in Firefox, viewBox is null for some reason
+        // set the viewbox to "0 0 0 0" to normalize
+        if (!element.getAttribute('viewBox')) {
+            element.setAttribute('viewBox', '0 0 0 0');
+        }
 
         const originalViewbox = {
             width: element.viewBox.baseVal.width,


### PR DESCRIPTION
## Description
Resizing svg images fails in Firefox because it returns `null` for the viewBox values if the viewBox is not set explicitly (Chrome properly returns "0 0 0 0").

## Testing
Eyeballing as unit testing map print is hard.

## Documentation
Source comments.

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [x] `gulp test` succeeds without warnings or errors
- [ ] release notes have been updated
- [x] all commit messages are descriptive and follow guidelines
- [x] PR targets the correct release version
- I will assign this PR to the primary reviewer

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/geoapi/173)
<!-- Reviewable:end -->
