### PR TITLE
fix(filter) show undefined when bad renderer

### DIFF
--- a/src/symbology.js
+++ b/src/symbology.js
@@ -88,8 +88,7 @@ function enhanceRenderer(renderer, legend) {
 */
 function searchRenderer(attributes, renderer) {
 
-    // make an empty svg graphic as a default, in case nothing is found
-    let svgcode = svgjs(document.createElement('div')).svg();
+    let svgcode;
     let symbol = {};
 
     switch (renderer.type) {
@@ -147,7 +146,9 @@ function searchRenderer(attributes, renderer) {
             // attempt to find the range our gVal belongs in
             const cbi = renderer.classBreakInfos.find((cbi, index) => gVal > minSplits[index] &&
                 gVal <= cbi.classMaxValue);
-            if (!cbi) { break; } // outside of range on the high end
+            if (!cbi) { // outside of range on the high end
+                break;
+            }
             svgcode = cbi.svgcode;
             symbol = cbi.symbol;
 
@@ -158,6 +159,11 @@ function searchRenderer(attributes, renderer) {
             // TODO set svgcode to blank image?
             console.warn(`Unknown renderer type encountered - ${renderer.type}`);
 
+    }
+
+    // make an empty svg graphic in case nothing is found to avoid undefined inside the filters
+    if (typeof svgcode === 'undefined') {
+        svgcode = svgjs(document.createElement('div')).svg();
     }
 
     return { svgcode, symbol };


### PR DESCRIPTION
## Description
<!-- Link to an issue (use #nnn for easy linking) or include a description -->
Replace undefine symbol by empty svg so we not have undefnied inside filters panel for symbol

## Testing
<!-- Have you added unit tests for this code?  If not explain why. -->
Visual

## Documentation
<!-- Which areas of documentation have been changed: jsdoc, tutorials, samples, wiki -->
Inline

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [x] `gulp test` succeeds without warnings or errors
- [] release notes have been updated
- [x] all commit messages are descriptive and follow guidelines
- [x] PR targets the correct release version
- I will assign this PR to the primary reviewer

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/geoapi/180)
<!-- Reviewable:end -->
