### PR TITLE
feat(legend): Add support for tile layers

### DIFF
--- a/test/testTileLegend.html
+++ b/test/testTileLegend.html
@@ -1,0 +1,24 @@
+
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>Test Page</title>
+    <style>
+        .layerTile { position: absolute; }
+    </style>
+</head>
+<body>
+    <p id="mess" />
+    <script src="../dist/geoapi.js"></script>
+    <script>
+        // http://localhost:6002/test/testServerLegend.html
+        geoapi('http://js.arcgis.com/3.14/', window).then(function (api) {
+            var mahLegendPromise = api.symbology.mapServerToLocalLegend('http://ec.gc.ca/arcgis/rest/services/Basemaps/OilSandsBasemap/MapServer');
+            mahLegendPromise.then(function (legend) {
+                console.log('this is my legend result', legend);
+            });
+        });
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Description
Adds a function `mapServerLegendToRendererAll` which is called when no `layerIndex` is provided to `mapServerToLocalLegend` for legend generation.

## Testing
testTileLegend.html

## Documentation
jsDoc

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [x] `gulp test` succeeds without warnings or errors
- [ ] release notes have been updated
- [x] all commit messages are descriptive and follow guidelines
- [x] PR targets the correct release version
- I will assign this PR to the primary reviewer

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/geoapi/185)
<!-- Reviewable:end -->
