### PR TITLE
fix(export): web mercator map should not rotation for north arrow

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "geoApi",
-  "version": "1.1.4",
+  "version": "1.1.4-1",
   "description": "",
   "main": "dist/geoapi.js",
   "dependencies": {

--- a/src/mapManager.js
+++ b/src/mapManager.js
@@ -187,25 +187,34 @@ module.exports = function (esriBundle, geoApi) {
      * @returns {Number} map rotation angle (in degree)
      */
     function getNorthArrowAngle(map) {
-        // get center point in longitude and use bottom value for latitude
-        const pointB = geoApi.proj.localProjectPoint(map.spatialReference, 'EPSG:4326',
-                { x: (map.extent.xmin + map.extent.xmax) / 2, y: map.extent.ymin });
 
-        // north value (set longitude to be half of Canada extent (141° W, 52° W))
-        const pointA = { x: -96, y: 90 };
+        // if web mercator, angle will be 180 (this projection always show north straight and 180 is pointing north)
+        let angle = 180;
 
-        // set info on longitude and latitude
-        const dLon = (pointB.x - pointA.x) * Math.PI / 180;
-        const lat1 = pointA.y * Math.PI / 180;
-        const lat2 = pointB.y * Math.PI / 180;
+        // if not web mercator calculate angle.
+        if (map.spatialReference.wkid !== 3857 && map.spatialReference.wkid !== 102100) {
+            // get center point in longitude and use bottom value for latitude
+            const pointB = geoApi.proj.localProjectPoint(map.spatialReference, 'EPSG:4326',
+                    { x: (map.extent.xmin + map.extent.xmax) / 2, y: map.extent.ymin });
 
-        // calculate bearing
-        const y = Math.sin(dLon) * Math.cos(lat2);
-        const x = Math.cos(lat1) * Math.sin(lat2) - Math.sin(lat1) * Math.cos(lat2) * Math.cos(dLon);
-        const bearing = Math.atan2(y, x) * 180 / Math.PI;
+            // north value (set longitude to be half of Canada extent (141° W, 52° W))
+            const pointA = { x: -96, y: 90 };
 
-        // return angle (180 is pointiong north)
-        return ((bearing + 360) % 360).toFixed(1);
+            // set info on longitude and latitude
+            const dLon = (pointB.x - pointA.x) * Math.PI / 180;
+            const lat1 = pointA.y * Math.PI / 180;
+            const lat2 = pointB.y * Math.PI / 180;
+
+            // calculate bearing
+            const y = Math.sin(dLon) * Math.cos(lat2);
+            const x = Math.cos(lat1) * Math.sin(lat2) - Math.sin(lat1) * Math.cos(lat2) * Math.cos(dLon);
+            const bearing = Math.atan2(y, x) * 180 / Math.PI;
+
+            // angle (180 is pointing north)
+            angle = ((bearing + 360) % 360).toFixed(1);
+        }
+
+        return angle;
     }
 
     /**


### PR DESCRIPTION
## Description
<!-- Link to an issue (use #nnn for easy linking) or include a description -->
No rotation for north arrow when we export map with mercator projection

Closes #1779

## Testing
<!-- Have you added unit tests for this code?  If not explain why. -->
Chrome

## Documentation
<!-- Which areas of documentation have been changed: jsdoc, tutorials, samples, wiki -->

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [x] `gulp test` succeeds without warnings or errors
- [ ] release notes have been updated
- [x] all commit messages are descriptive and follow guidelines
- [x] PR targets the correct release version
- I will assign this PR to the primary reviewer

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/geoapi/188)
<!-- Reviewable:end -->
