### PR TITLE
fix(events): add return event object to access it from outside

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "geoApi",
-  "version": "1.1.5",
+  "version": "1.1.6-1",
   "description": "",
   "main": "dist/geoapi.js",
   "dependencies": {

--- a/src/events.js
+++ b/src/events.js
@@ -4,15 +4,18 @@
  *
  * @param {esriObject} esriObject which contains the dojo events to be wrapped
  * @param {handlers} handlers is an object which contains all handlers needed
+ *
+ * @return {object} evt contains the events created on the object, keyed by same properties as handlers input
  */
 function wrapEvents(esriObject, handlers) {
+    const evt = {};
     Object.keys(handlers).forEach(ourEventName => {
         // replace camelCase name to dojo event name format
         const dojoName = ourEventName.replace(/([a-z])([A-Z])/g, '$1-$2').toLowerCase();
 
         // TODO: Validity checking on inputs for dojoName
         // make dojo call
-        esriObject.on(dojoName, (e) => {
+        evt[ourEventName] = esriObject.on(dojoName, (e) => {
 
             // check if needs special handling to point at layer calling event
             const layerEvents = ['update-start', 'update-end', 'error'];
@@ -22,6 +25,8 @@ function wrapEvents(esriObject, handlers) {
             handlers[ourEventName](e);
         });
     });
+
+    return evt;
 }
 
 module.exports = () => {

--- a/test/testEvents.html
+++ b/test/testEvents.html
@@ -12,6 +12,7 @@
     <p id="mess" />
     <script src="../dist/geoapi.js"></script>
     <script>
+        var evt;
         geoapi('http://js.arcgis.com/3.14/', window).then(function (api) {
             var map = api.mapManager.Map(document.getElementById('map'), { basemap: 'topo', zoom: 6, center: [-100, 50] });
             var layer = new api.layer.FeatureLayer('http://maps-cartes.ec.gc.ca/ArcGIS/rest/services/Oilsands/MapServer/0');
@@ -21,6 +22,12 @@
                 console.log(x);
                 console.log(x.layer);
                 console.log(x.target);
+                }
+            });
+
+            evt = api.events.wrapEvents(map, { click: (clickEvent) => {
+                console.log(clickEvent.mapPoint.x);
+                evt.click.remove();
                 }
             });
         });


### PR DESCRIPTION
Closes #1858

## Description
<!-- Link to an issue (use #nnn for easy linking) or include a description -->
When we create a evant, it is return to the caller so we can access it to e.g. remote it.

## Testing
<!-- Have you added unit tests for this code?  If not explain why. -->
In testEvents.html

## Documentation
<!-- Which areas of documentation have been changed: jsdoc, tutorials, samples, wiki -->
Inline

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [x] `gulp test` succeeds without warnings or errors
- [***no release note tag for 1.1.6-1***] release notes have been updated
- [x] all commit messages are descriptive and follow guidelines
- [x] PR targets the correct release version
- I will assign this PR to the primary reviewer

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/geoapi/191)
<!-- Reviewable:end -->
