### PR TITLE
fix(mapManager): get spatialReference from map extent

### DIFF
--- a/src/mapManager.js
+++ b/src/mapManager.js
@@ -192,9 +192,9 @@ module.exports = function (esriBundle, geoApi) {
         let angle = 180;
 
         // if not web mercator calculate angle.
-        if (map.spatialReference.wkid !== 3857 && map.spatialReference.wkid !== 102100) {
+        if (map.extent.spatialReference.wkid !== 3857 && map.extent.spatialReference.wkid !== 102100) {
             // get center point in longitude and use bottom value for latitude
-            const pointB = geoApi.proj.localProjectPoint(map.spatialReference, 'EPSG:4326',
+            const pointB = geoApi.proj.localProjectPoint(map.extent.spatialReference, 'EPSG:4326',
                     { x: (map.extent.xmin + map.extent.xmax) / 2, y: map.extent.ymin });
 
             // north value (set longitude to be half of Canada extent (141° W, 52° W))


### PR DESCRIPTION
## Description
Fixes north arrow issue on geo4 where spatialReference is initially missing on map object. Using spatialReference from the map extent works.

## Testing
None

## Documentation
None

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [x] `gulp test` succeeds without warnings or errors
- [x] ~~release notes have been updated~~
- [x] all commit messages are descriptive and follow guidelines
- [x] PR targets the correct release version
- I will assign this PR to the primary reviewer

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/geoapi/194)
<!-- Reviewable:end -->
