### PR TITLE
Use Timeout to Prevent Cascading Visibility Refreshes

### DIFF
--- a/src/layer/layerRec/basicFC.js
+++ b/src/layer/layerRec/basicFC.js
@@ -48,11 +48,12 @@ class BasicFC extends placeholderFC.PlaceholderFC {
     }
 
     /**
-     * Indicates if the feature class is not visible at the given scale.
+     * Indicates if the feature class is not visible at the given scale,
+     * and if so, if we need to zoom in to see it or zoom out
      *
      * @function isOffScale
      * @param {Integer}  mapScale the scale to test against
-     * @returns {Boolean} true if layer is not visible at the scale
+     * @returns {Object} has boolean properties `offScale` and `zoomIn`
      */
     isOffScale (mapScale) {
         const scaleSet = this.getScaleSet();

--- a/src/layer/layerRec/dynamicRecord.js
+++ b/src/layer/layerRec/dynamicRecord.js
@@ -421,12 +421,13 @@ class DynamicRecord extends attribRecord.AttribRecord {
     }
 
     /**
-     * Indicates if the child layer is not visible at the given scale.
+     * Indicates if the feature class is not visible at the given scale,
+     * and if so, if we need to zoom in to see it or zoom out
      *
      * @function isOffScale
      * @param {String}  childIndex    index of the child layer to target
      * @param {Integer}  mapScale the scale to test against
-     * @returns {Boolean} true if layer is not visible at the scale
+     * @returns {Object} has boolean properties `offScale` and `zoomIn`
      */
     isOffScale (childIdx, mapScale) {
         return this._featClasses[childIdx].isOffScale(mapScale);

--- a/src/layer/layerRec/dynamicRecord.js
+++ b/src/layer/layerRec/dynamicRecord.js
@@ -61,6 +61,13 @@ class DynamicRecord extends attribRecord.AttribRecord {
         // TODO ensure false is best default (what is better for UI)
         this._isTrueDynamic = false;
 
+        // manages delayed visibility changes to avoid cascading refreshes
+        this._visDelay = {
+            lastIdx: -1,
+            parentToggle: false,
+            parentValue: false
+        };
+
     }
 
     /**

--- a/src/layer/layerRec/layerRecord.js
+++ b/src/layer/layerRec/layerRecord.js
@@ -353,11 +353,12 @@ class LayerRecord extends root.Root {
     }
 
     /**
-     * Indicates if the layer is not visible at the given scale.
+     * Indicates if the feature class is not visible at the given scale,
+     * and if so, if we need to zoom in to see it or zoom out
      *
      * @function isOffScale
      * @param {Integer}  mapScale the scale to test against
-     * @returns {Boolean} true if layer is not visible at the scale
+     * @returns {Object} has boolean properties `offScale` and `zoomIn`
      */
     isOffScale (mapScale) {
         return this._featClasses[this._defaultFC].isOffScale(mapScale);

--- a/test/lr/DynamicLR3.js
+++ b/test/lr/DynamicLR3.js
@@ -1,0 +1,146 @@
+import geoapi from '../../src/index';
+
+// https://github.com/fgpv-vpgf/geoApi/wiki/Locally-Testing-GeoAPI
+// to run, temporarily update package.json
+// "main": "test/lr/DynamicLR3.js"
+
+geoapi('http://js.arcgis.com/3.14/', window).then(function (api) {
+    console.log('TEST PAGE - Visibility Delay on Dynamic Layer Record');
+
+    var config1 = {
+        id: 'guts',
+        name: 'Dynamic Test',
+        url: 'http://maps-cartes.ec.gc.ca/arcgis/rest/services/CESI/CESI_Air_SO2/MapServer',                
+        metadataUrl: 'http://www.github.com',
+        layerType: 'esriDynamic',
+        tolerance: 5,   
+        state: {
+            opacity: 1,
+            visibility: true,
+            boundingBox: false,
+            query: true
+        },
+        layerEntries: [
+            {
+                index: 1,
+                outfields: '*',                       
+                state: {
+                    opacity: 1,
+                    visibility: true,
+                    boundingBox: false,
+                    query: true
+                },
+                stateOnly: false,
+                name: 'Hamhocks One'
+            },
+            {
+                index: 2,
+                outfields: '*',                       
+                state: {
+                    opacity: 1,
+                    visibility: true,
+                    boundingBox: false,
+                    query: true
+                },
+                stateOnly: false,
+                name: 'Hamhocks Two'
+            },
+            {
+                index: 3,
+                outfields: '*',                       
+                state: {
+                    opacity: 1,
+                    visibility: true,
+                    boundingBox: false,
+                    query: true
+                },
+                stateOnly: false,
+                name: 'Hamhocks Three'
+            },
+            {
+                index: 4,
+                outfields: '*',                       
+                state: {
+                    opacity: 1,
+                    visibility: true,
+                    boundingBox: false,
+                    query: true
+                },
+                stateOnly: false,
+                name: 'Hamhocks Four'
+            },
+        ]
+    };
+
+    var layerRec = api.layer.createDynamicRecord(config1);
+    console.log('layer PROOF ', layerRec);
+    var proxy = layerRec.getProxy();
+    console.log('proxy PROOF ', proxy);
+
+    // hack to wait for layer to load
+
+    var to = setInterval(() => {
+        if (layerRec.state === 'rv-loaded') {
+            clearInterval(to);
+            afterLoadTests();
+        }
+    }, 1000);
+
+    function afterLoadTests() {
+        console.log('enhanced loaded')
+
+        // everything starts off invisible
+        var leaf4proxy = layerRec.getChildProxy(4);
+        var leaf3proxy = layerRec.getChildProxy(3);
+        var leaf2proxy = layerRec.getChildProxy(2);
+        var leaf1proxy = layerRec.getChildProxy(1);
+
+
+        // from invisible to semi visible
+
+        leaf2proxy.setVisibility(true);
+        leaf3proxy.setVisibility(true);
+        leaf4proxy.setVisibility(true);
+
+        console.log('leaf 4 should refresh the layer');
+
+
+        /*
+        // from visible to invisible
+
+        // prep the layer to be visible with two kids on
+        leaf2proxy.setVisibility(true);
+        leaf3proxy.setVisibility(true);
+
+        // wait a bit for prep timers to finish
+        var toTo = setTimeout(() => {
+            
+            clearTimeout(toTo);
+
+            console.log('starting timed test. leaf 3 should refresh the layer');
+            leaf2proxy.setVisibility(false);
+            leaf3proxy.setVisibility(false);
+
+        }, 1000);
+        */
+
+        /*
+        // from visible to visible
+
+        // prep the layer to be visible with one kid on
+        leaf2proxy.setVisibility(true);
+
+        // wait a bit for prep timers to finish
+        var toTo = setTimeout(() => {
+            
+            clearTimeout(toTo);
+
+            console.log('starting timed test. leaf 1 should refresh the layer');
+            leaf3proxy.setVisibility(true);
+            leaf1proxy.setVisibility(true);
+
+        }, 1000);
+        */
+    }
+
+});


### PR DESCRIPTION
## Description
<!-- Link to an issue (use #nnn for easy linking) or include a description -->
https://github.com/fgpv-vpgf/fgpv-vpgf/issues/1958

If a group of a dynamic layer is updating visibility, don't cause the layer to reload until all child updates have been processed.

## Testing
<!-- Have you added unit tests for this code?  If not explain why. -->

## Documentation
<!-- Which areas of documentation have been changed: jsdoc, tutorials, samples, wiki -->

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [ ] `gulp test` succeeds without warnings or errors
- [ ] release notes have been updated
- [ ] all commit messages are descriptive and follow guidelines
- [ ] PR targets the correct release version
- I will assign this PR to the primary reviewer

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/geoapi/229)
<!-- Reviewable:end -->
