### PR TITLE
CSV Spaces, Server File Loading

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "geoApi",
-  "version": "0.0.0-protoLR-77",
+  "version": "0.0.0-protoLR-78",
   "description": "",
   "main": "src/index.js",
   "dependencies": {

--- a/src/layer.js
+++ b/src/layer.js
@@ -839,6 +839,69 @@ function extractFields(geoJson) {
 }
 
 /**
+ * Rename any fields with invalid names. Both parameters are modified in place.
+ *
+ * @function cleanUpFields
+ * @param {Object} geoJson           layer data in geoJson format
+ * @param {Object} layerDefinition   layer definition of feature layer not yet created
+ */
+function cleanUpFields(geoJson, layerDefinition) {
+    /*
+        loop through layerDef fields
+        if we find a bad field
+            store orig name
+            loop
+                make a new name -- spaces to underscore
+                check if new name exists fields
+                if yes, increase underscores
+                if no, exit loop
+            end loop
+            add alias to fieldDef equal to name
+            update fieldDef name to be newName
+
+            loop through geoJson features
+            update new property
+            delete old property
+        end if
+
+    */
+
+    const badField = name => {
+        // basic for now. check for spaces.
+        return name.indexOf(' ') > -1;
+    };
+
+    layerDefinition.fields.forEach(f => {
+        if (badField(f.name)) {
+            const oldField = f.name;
+            let newField;
+            let underscore = '_';
+            let badNewName;
+
+            // determine a new field name that is not bad and is unique, then update the field definition
+            do {
+                newField = oldField.replace(/ /g, underscore);
+                badNewName = layerDefinition.fields.find(f2 => f2.name === newField);
+                if (badNewName) {
+                    // new field already exists. enhance it
+                    underscore += '_';
+                }
+            } while (badNewName)
+
+            f.alias = oldField;
+            f.name = newField;
+
+            // update the geoJson to reflect the field name change.
+            geoJson.features.forEach(gf => {
+                gf.properties[newField] = gf.properties[oldField];
+                delete gf.properties[oldField];
+            });
+        }
+    });
+
+}
+
+/**
  * Makes an attempt to load and register a projection definition.
  * Returns promise resolving when process is complete
  * projModule - proj module from geoApi
@@ -941,6 +1004,10 @@ function makeGeoJsonLayerBuilder(esriBundle, geoApi) {
             layerDefinition.fields = layerDefinition.fields.concat(extractFields(geoJson));
         }
 
+        // clean the fields. in particular, CSV files can be loaded with spaces in
+        // the field names
+        cleanUpFields(geoJson, layerDefinition);
+
         const destProj = 'EPSG:' + targetWkid;
 
         // look up projection definitions if they don't already exist and we have enough info
@@ -978,7 +1045,6 @@ function makeGeoJsonLayerBuilder(esriBundle, geoApi) {
 
                 // initializing layer using JSON does not set this property. do it manually.
                 layer.geometryType = geometryType;
-
                 resolve(layer);
             });
         };

--- a/src/layer/layerRec/featureRecord.js
+++ b/src/layer/layerRec/featureRecord.js
@@ -112,6 +112,21 @@ class FeatureRecord extends attribRecord.AttribRecord {
         const pLD = aFC.getLayerData().then(ld => {
             aFC.geomType = ld.geometryType;
             aFC.nameField = this.config.nameField || ld.nameField || '';
+
+            // trickery. file layer can have field names that are bad keys.
+            // our file loader will have corrected them, but config.nameField will have
+            // been supplied from the wizard (it pre-fetches fields to present a choice
+            // to the user). If the nameField was adjusted for bad characters, we need to
+            // re-synchronize it here.
+            if (this.isFileLayer() && ld.fields.findIndex(f => f.name === aFC.nameField) === -1) {
+                const validField = ld.fields.find(f => f.alias === aFC.nameField);
+                if (validField) {
+                    aFC.nameField = validField.name;
+                } else {
+                    // give warning. impact is tooltips will have no text, details pane no header
+                    console.warn(`Cannot find name field in layer field list: ${aFC.nameField}`);
+                }
+            }
         });
 
         const pFC = this.getFeatureCount().then(fc => {


### PR DESCRIPTION
## Description
<!-- Link to an issue (use #nnn for easy linking) or include a description -->
Handles spaces in field names for CSV files, in support of https://github.com/fgpv-vpgf/fgpv-vpgf/issues/1856 and something Johann is doing in the grid.
No longer attempts to load files residing on web servers, in support of https://github.com/fgpv-vpgf/fgpv-vpgf/issues/2061

## Testing
<!-- Have you added unit tests for this code?  If not explain why. -->
Tested against application. Loading layers and files. Loading CSV files that are normal, have field spaces, have field spaces that collide with identical field with underscores.

## Documentation
<!-- Which areas of documentation have been changed: jsdoc, tutorials, samples, wiki -->

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [ ] `gulp test` succeeds without warnings or errors
- [ ] release notes have been updated
- [ ] all commit messages are descriptive and follow guidelines
- [ ] PR targets the correct release version
- I will assign this PR to the primary reviewer

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/geoapi/242)
<!-- Reviewable:end -->
