### PR TITLE
fetchGraphic performance upgrade

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "geoApi",
-  "version": "2.1.0-8",
+  "version": "2.1.0-9",
   "description": "",
   "main": "src/index.js",
   "dependencies": {

--- a/src/attribute.js
+++ b/src/attribute.js
@@ -36,7 +36,7 @@ it contains the attribute data as an array, and an index mapping object id to ar
         },
         ...
     ],
-        "oidIndex": {
+    "oidIndex": {
         "23": 0,
         ...
     }
@@ -78,6 +78,7 @@ function newLayerPackage(featureIdx, esriBundle) {
         getAttribs,
         loadedFeatureCount: 0,
         loadAbortFlag: false,
+        loadIsDone: false,
         abortAttribLoad
     };
 
@@ -120,6 +121,7 @@ function newLayerPackage(featureIdx, esriBundle) {
                 // after all data has been loaded
                 defFinished.promise.then(features => {
                     delete layerData.load; // no longer need this info
+                    layerPackage.loadIsDone = true;
 
                     // resolve the promise with the attribute set
                     resolve(createAttribSet(layerData.oidField, features));

--- a/src/layer/layerRec/attribRecord.js
+++ b/src/layer/layerRec/attribRecord.js
@@ -94,12 +94,15 @@ class AttribRecord extends layerRecord.LayerRecord {
      * Will attempt local copy (unless overridden), will hit the server if not available.
      *
      * @function fetchGraphic
-     * @param  {Integer} objId          ID of object being searched for
-     * @param  {Boolean} ignoreLocal    indicates if we should ignore any local graphic in the layer. cached or server value will be used. defaults to false.
-     * @returns {Promise} resolves with a bundle of information. .graphic is the graphic; .source is where it came from - 'layer' or 'server'; also .layerFC for convenience
+     * @param  {Integer} objId         ID of object being searched for
+     * @param {Object} opts            object containing option parametrs
+     *                 - map           map wrapper object of current map. only required if requesting geometry
+     *                 - geom          boolean. indicates if return value should have geometry included. default to false
+     *                 - attribs       boolean. indicates if return value should have attributes included. default to false
+     * @returns {Promise} resolves with a bundle of information. .graphic is the graphic; .layerFC for convenience
      */
-    fetchGraphic (objId, ignoreLocal = false) {
-        return this._featClasses[this._defaultFC].fetchGraphic(objId, ignoreLocal);
+    fetchGraphic (objId, opts) {
+        return this._featClasses[this._defaultFC].fetchGraphic(objId, opts);
     }
 
     /**

--- a/src/layer/layerRec/dynamicRecord.js
+++ b/src/layer/layerRec/dynamicRecord.js
@@ -508,22 +508,25 @@ class DynamicRecord extends attribRecord.AttribRecord {
      * Will attempt local copy (unless overridden), will hit the server if not available.
      *
      * @function fetchGraphic
-     * @param {String}  childIndex    index of the child layer to target
-     * @param  {Integer} objId          ID of object being searched for
-     * @param  {Boolean} ignoreLocal    indicates if we should ignore any local graphic in the layer. cached or server value will be used. defaults to false.
-     * @returns {Promise} resolves with a bundle of information. .graphic is the graphic; .source is where it came from - 'layer' or 'server'; also .layerFC for convenience
+     * @param {String}  childIndex     index of the child layer to target
+     * @param {Integer} objId          ID of object being searched for
+     * @param {Object} opts            object containing option parametrs
+     *                 - map           map wrapper object of current map. only required if requesting geometry
+     *                 - geom          boolean. indicates if return value should have geometry included. default to false
+     *                 - attribs       boolean. indicates if return value should have attributes included. default to false
+     * @returns {Promise} resolves with a bundle of information. .graphic is the graphic; .layerFC for convenience
      */
-    fetchGraphic (childIndex, objId, ignoreLocal = false) {
-        return this._featClasses[childIndex].fetchGraphic(objId, ignoreLocal);
+    fetchGraphic (childIndex, objId, opts) {
+        return this._featClasses[childIndex].fetchGraphic(objId, opts);
     }
 
     /**
      * Will attempt to zoom the map view so the a graphic is prominent.
      *
      * @function zoomToGraphic
-     * @param {String}  childIndex    index of the child layer to target
-     * @param  {Integer} objId          Object ID of grahpic being searched for
-     * @param  {Object} map             wrapper object for the map we want to zoom
+     * @param {String}  childIndex      index of the child layer to target
+     * @param {Integer} objId           Object ID of grahpic being searched for
+     * @param {Object} map              wrapper object for the map we want to zoom
      * @param {Object} offsetFraction   an object with decimal properties `x` and `y` indicating percentage of offsetting on each axis
      * @return {Promise}                resolves after the map is done moving
      */

--- a/src/layer/layerRec/featureRecord.js
+++ b/src/layer/layerRec/featureRecord.js
@@ -194,25 +194,6 @@ class FeatureRecord extends attribRecord.AttribRecord {
      * @param {Object} standard mouse event object
      */
     onMouseOver (e) {
-        /* discussion on quick-lookup.
-        there are two different ways to get attributes from the server for a single feature.
-        1. using the feature rest endpoint (FR)
-        2. using the feature layer's query rest endpoint (FQ)
-        FR returns a smaller response object (it omits a pile of layer metadata). this is good.
-        FR is used in the hilight module. so we are already caching that response and have the
-        code to make the FR request. this is good.
-        FR always includes the geometry. which means if we hover over a feature with massive geometry and
-        a small attribute set, we will download way more data than we want. this is bad.
-        FQ has a larger response in general (metadata that we dont care about). this is bad.
-        FQ can omit the geometry. this is good.
-        FQ is not being used elsewhere, so we would have to write a new function and cache. this is bad.
-        Conclusion:  for time being, we will use the FR approach. In most cases it will be faster. The
-        one potential problem (massive geometry polys) would only have the impact of the maptip not showing
-        promptly (or timing out).
-        If we find this is a major issue, suggest re-doing fetchGraphic to use FQ for both hover and hilight,
-        adding parameters to include or omit the geometry.
-        */
-
         if (this._hoverListeners.length > 0) {
 
             const showBundle = {
@@ -229,33 +210,11 @@ class FeatureRecord extends attribRecord.AttribRecord {
             this.getLayerData().then(lInfo => {
                 // graphic attributes will only have the OID if layer is server based
                 oid = e.graphic.attributes[lInfo.oidField];
+                const graphicPromise = this.fetchGraphic(oid, { attribs: true });
+                return Promise.all([Promise.resolve(lInfo), graphicPromise]);
+            }).then(([lInfo, graphicBundle]) => {
 
-                let attribSetPromise;
-                if (this._featClasses[this._defaultFC].attribsLoaded()) {
-                    // we have already pulled attributes from the server. use them.
-                    attribSetPromise = this.getAttribs();
-                } else {
-                    // we have not pulled attributes from the server.
-                    // instead of downloading them all, just get the one
-                    // we are interested in.
-                    // we skip the client side graphic attributes if we are server based, as it will
-                    // only contain the OID.  File based layers will have all the attributes client side.
-                    attribSetPromise = this.fetchGraphic(oid, !this.isFileLayer()).then(graphicBundle => {
-                        const fakeSet = {
-                            features: [
-                                graphicBundle.graphic
-                            ],
-                            oidIndex: {}
-                        };
-                        fakeSet.oidIndex[oid] = 0; // because only one feature added above
-                        return fakeSet;
-                    });
-                }
-                return Promise.all([Promise.resolve(lInfo), attribSetPromise]);
-            }).then(([lInfo, aInfo]) => {
-
-                // get name via attribs and name field
-                const featAttribs = aInfo.features[aInfo.oidIndex[oid]].attributes;
+                const featAttribs = graphicBundle.graphic.attributes;
 
                 // get icon via renderer and geoApi call
                 const svgcode = this._apiRef.symbology.getGraphicIcon(featAttribs, lInfo.renderer);

--- a/src/layer/layerRec/layerInterface.js
+++ b/src/layer/layerRec/layerInterface.js
@@ -71,7 +71,7 @@ class LayerInterface {
     // param: boolean
     setQuery () { return undefined; }
 
-    // param: integer, boolean (optional)
+    // param: integer, object
     fetchGraphic () { return undefined; } // returns promise that resolves with object containing graphics info
 
     // param: esriMap
@@ -459,14 +459,14 @@ function dynamicLeafAttributesToDetails(attribs, fields) {
     return this._source._parent.attributesToDetails(attribs, fields);
 }
 
-function featureFetchGraphic(oid, ignoreLocal = false) {
+function featureFetchGraphic(oid, opts) {
     /* jshint validthis: true */
-    return this._source.fetchGraphic(oid, ignoreLocal);
+    return this._source.fetchGraphic(oid, opts);
 }
 
-function dynamicLeafFetchGraphic(oid, ignoreLocal = false) {
+function dynamicLeafFetchGraphic(oid, opts) {
     /* jshint validthis: true */
-    return this._source.fetchGraphic(oid, ignoreLocal);
+    return this._source.fetchGraphic(oid, opts);
 }
 
 function featureZoomToGraphic(oid, map, offsetFraction) {

--- a/src/layer/layerRec/layerRecord.js
+++ b/src/layer/layerRec/layerRecord.js
@@ -251,6 +251,16 @@ class LayerRecord extends root.Root {
     }
 
     /**
+     * Indicates if layer is file based.
+     *
+     * @function isFileLayer
+     */
+    isFileLayer () {
+        // only instances of FeatureLayer can be file based; that class overrides this function
+        return false;
+    }
+
+    /**
      * Creates an options object for the map API object
      *
      * @function makeLayerConfig

--- a/src/map/esriMap.js
+++ b/src/map/esriMap.js
@@ -12,9 +12,9 @@ function esriMap(esriBundle, geoApi) {
 
         // TODO when jshint parses instance fields properly we can change this from a property to a field
         get _passthroughBindings () { return [
-            'addLayer', 'centerAndZoom', 'centerAt', 'destroy', 'disableKeyboardNavigation', 'getScale', 'on',
-            'removeLayer', 'reorderLayer', 'reposition', 'resize', 'setExtent', 'setMapCursor', 'setScale',
-            'setZoom', 'toMap', 'toScreen'
+            'addLayer', 'centerAndZoom', 'centerAt', 'destroy', 'disableKeyboardNavigation', 'getLevel',
+            'getScale', 'on', 'removeLayer', 'reorderLayer', 'reposition', 'resize', 'setExtent',
+            'setMapCursor', 'setScale', 'setZoom', 'toMap', 'toScreen'
         ]; }
         get _passthroughProperties () { return [
             'attribution', 'extent', 'graphicsLayerIds', 'height', 'layerIds', 'spatialReference', 'width'


### PR DESCRIPTION
## Description
<!-- Link to an issue (use #nnn for easy linking) or include a description -->

`fetchGraphic` will now only get the information it requires. Caching is split across attributes and geometry.
For lines & polygons, geometry is simplified to the current scale level. The geometry cache also indexes by scale level.

Closes https://github.com/fgpv-vpgf/fgpv-vpgf/issues/2190
Helps mitigate issues in https://github.com/fgpv-vpgf/fgpv-vpgf/issues/2293

## Testing
<!-- Have you added unit tests for this code?  If not explain why. -->

Tested against real data.

## Documentation
<!-- Which areas of documentation have been changed: jsdoc, tutorials, samples, wiki -->
jsdoc

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [ ] `gulp test` succeeds without warnings or errors
- [ ] release notes have been updated
- [x] all commit messages are descriptive and follow guidelines
- [x] PR targets the correct release version
- I will assign this PR to the primary reviewer

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/geoapi/260)
<!-- Reviewable:end -->
