### PR TITLE
latestWkid support

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "geoApi",
-  "version": "2.1.0-9",
+  "version": "2.1.0-10",
   "description": "",
   "main": "src/index.js",
   "dependencies": {


### PR DESCRIPTION
## Description
<!-- Link to an issue (use #nnn for easy linking) or include a description -->

Supports item 1 of https://github.com/fgpv-vpgf/fgpv-vpgf/issues/2234

Updated projection lookup to consider the `latestWkid` field, if available, and with priority (as it often is the EPSG code rather than the ESRI code).

Removed similar projection management code from geoJson loader.

## Testing
<!-- Have you added unit tests for this code?  If not explain why. -->

Tested against various layers

- files
- files with defined with projections
- services with known projections
- services with unknown projections
- services with unknown projections with latestWkid
- reloading services with unknown projections (verified cached projection was used)

## Documentation
<!-- Which areas of documentation have been changed: jsdoc, tutorials, samples, wiki -->

jsdoc

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [ ] `gulp test` succeeds without warnings or errors
- [ ] release notes have been updated
- [x] all commit messages are descriptive and follow guidelines
- [x] PR targets the correct release version
- I will assign this PR to the primary reviewer

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/geoapi/261)
<!-- Reviewable:end -->
