### PR TITLE
Handle unmarked objectid

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "geoApi",
-  "version": "2.1.0-10",
+  "version": "2.1.0-11",
   "description": "",
   "main": "src/index.js",
   "dependencies": {

--- a/src/attribute.js
+++ b/src/attribute.js
@@ -333,7 +333,8 @@ function loadServerAttribsBuilder(esriBundle, geoApi) {
                         if (noFieldDefOid) {
                             // we encountered a service that does not mark a field as the object id.
                             // attempt to use alternate definition. if neither exists, we are toast.
-                            layerData.oidField = serviceResult.objectIdField
+                            layerData.oidField = serviceResult.objectIdField ||
+                                console.error(`Encountered service with no OID defined: ${layerUrl}`);
                         }
 
                         // ensure our attribute list contains the object id

--- a/src/attribute.js
+++ b/src/attribute.js
@@ -321,7 +321,7 @@ function loadServerAttribsBuilder(esriBundle, geoApi) {
 
                         // find object id field
                         // NOTE cannot use arrow functions here due to bug
-                        serviceResult.fields.every(function (elem) {
+                        const noFieldDefOid = serviceResult.fields.every(function (elem) {
                             if (elem.type === 'esriFieldTypeOID') {
                                 layerData.oidField = elem.name;
                                 return false; // break the loop
@@ -329,6 +329,12 @@ function loadServerAttribsBuilder(esriBundle, geoApi) {
 
                             return true; // keep looping
                         });
+
+                        if (noFieldDefOid) {
+                            // we encountered a service that does not mark a field as the object id.
+                            // attempt to use alternate definition. if neither exists, we are toast.
+                            layerData.oidField = serviceResult.objectIdField
+                        }
 
                         // ensure our attribute list contains the object id
                         if (attribs !== '*') {


### PR DESCRIPTION
## Description
<!-- Link to an issue (use #nnn for easy linking) or include a description -->
Closes https://github.com/fgpv-vpgf/fgpv-vpgf/issues/2352

Some feature layer services appear to not mark which field is the object id. Made a change to recognize when this happens, and if so, attempt to get the object id from an alternate property.

## Testing
<!-- Have you added unit tests for this code?  If not explain why. -->

Tested normal layer and layer without a marked oid field

## Documentation
<!-- Which areas of documentation have been changed: jsdoc, tutorials, samples, wiki -->
jsdoc

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [ ] `gulp test` succeeds without warnings or errors
- [x] release notes have been updated
- [x] all commit messages are descriptive and follow guidelines
- [x] PR targets the correct release version
- I will assign this PR to the primary reviewer

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/geoapi/262)
<!-- Reviewable:end -->
