### PR TITLE
Use mapName from service as name for a legend entry if not provided

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "geoApi",
-  "version": "v2.0.1-5",
+  "version": "v2.0.1-6",
   "description": "",
   "main": "src/index.js",
   "dependencies": {

--- a/src/layer/layerRec/dynamicRecord.js
+++ b/src/layer/layerRec/dynamicRecord.js
@@ -406,6 +406,19 @@ class DynamicRecord extends attribRecord.AttribRecord {
             this._layer.setVisibleLayers([-1]);
         }
 
+        // get mapName of the legend entry from the service to use as the name if not provided in config
+        if (!this.name) {
+            const defService = this._esriRequest({
+                url: this._layer.url + '?f=json',
+                callbackParamName: 'callback',
+                handleAs: 'json',
+            });
+            const setTitle = defService.then(serviceResult => {
+                this.name = serviceResult.mapName;
+            });
+            loadPromises.push(setTitle);
+        }
+
         Promise.all(loadPromises).then(() => {
             this._stateChange(shared.states.LOADED);
         });
@@ -494,7 +507,7 @@ class DynamicRecord extends attribRecord.AttribRecord {
 
     /**
      * Retrieves attributes from a layer for a specified feature index
-     * 
+     *
      * @function getFormattedAttributes
      * @param {String}  childIndex  index of the child layer to get attributes for
      * @return {Promise}            promise resolving with formatted attributes to be consumed by the datagrid and esri feature identify


### PR DESCRIPTION
## Description
<!-- Link to an issue (use #nnn for easy linking) or include a description -->
Relates to https://github.com/fgpv-vpgf/fgpv-vpgf/issues/2364

Get the `mapName` from the service to use as the name for the top level dynamic legend entry if the name is not provided in the config

## Testing
<!-- Have you added unit tests for this code?  If not explain why. -->
Manually
## Documentation
<!-- Which areas of documentation have been changed: jsdoc, tutorials, samples, wiki -->
NA
## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [x] `npm run test` succeeds without warnings or errors
- [x] all commit messages are descriptive and follow guidelines
- [x] PR targets the correct release version
- I will assign this PR to the primary reviewer

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/geoapi/266)
<!-- Reviewable:end -->
