### PR TITLE
Child Opacity and Dynamic Image Formats

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "geoApi",
-  "version": "2.2.1-1",
+  "version": "2.2.1-2",
   "description": "",
   "main": "src/index.js",
   "dependencies": {

--- a/src/index.js
+++ b/src/index.js
@@ -65,6 +65,7 @@ module.exports = function (esriLoaderUrl, window) {
         ['esri/layers/ArcGISTiledMapServiceLayer', 'ArcGISTiledMapServiceLayer'],
         ['esri/layers/FeatureLayer', 'FeatureLayer'],
         ['esri/layers/GraphicsLayer', 'GraphicsLayer'],
+        ['esri/layers/ImageParameters', 'ImageParameters'],
         ['esri/layers/LayerDrawingOptions', 'LayerDrawingOptions'],
         ['esri/layers/WMSLayer', 'WmsLayer'],
         ['esri/map', 'Map'],

--- a/src/layer.js
+++ b/src/layer.js
@@ -1227,6 +1227,7 @@ module.exports = function (esriBundle, geoApi) {
         ScreenPoint: esriBundle.ScreenPoint,
         Query: esriBundle.Query,
         TileLayer: esriBundle.ArcGISTiledMapServiceLayer,
+        ImageParameters: esriBundle.ImageParameters,
         ogc: ogc(esriBundle),
         bbox: bbox(esriBundle, geoApi),
         createImageRecord: createImageRecordBuilder(esriBundle, geoApi, layerClassBundle),

--- a/src/layer/layerRec/dynamicFC.js
+++ b/src/layer/layerRec/dynamicFC.js
@@ -48,11 +48,12 @@ class DynamicFC extends attribFC.AttribFC {
             if (this.supportsOpacity) {
                 // only attempt to set the layer if we support that kind of magic.
                 // instead of being consistent, esri using value from 0 to 100 for sublayer transparency where 100 is fully transparent
-                const optionsArray = [];
-                const drawingOptions = new this._parent._apiRef.layer.LayerDrawingOptions();
+                const realLayer = this._parent._layer;
+                const optionsArray = realLayer.layerDrawingOptions || [];
+                const drawingOptions = optionsArray[this._idx] || new this._parent._apiRef.layer.LayerDrawingOptions();
                 drawingOptions.transparency = (value - 1) * -100;
                 optionsArray[this._idx] = drawingOptions;
-                this._parent._layer.setLayerDrawingOptions(optionsArray);
+                realLayer.setLayerDrawingOptions(optionsArray);
             } else {
                 // update the opacity on the parent and any sibling children
                 this._parent.synchOpacity(value);

--- a/src/layer/layerRec/dynamicRecord.js
+++ b/src/layer/layerRec/dynamicRecord.js
@@ -84,7 +84,7 @@ class DynamicRecord extends attribRecord.AttribRecord {
     makeLayerConfig () {
         const cfg = super.makeLayerConfig();
         cfg.imageParameters = new this._apiRef.layer.ImageParameters();
-        cfg.imageParameters.format = 'png32';
+        cfg.imageParameters.format = this.config.imageFormat || 'png32';
 
         return cfg;
     }

--- a/src/layer/layerRec/dynamicRecord.js
+++ b/src/layer/layerRec/dynamicRecord.js
@@ -76,6 +76,20 @@ class DynamicRecord extends attribRecord.AttribRecord {
     }
 
     /**
+     * Creates an options object for the map API object
+     *
+     * @function makeLayerConfig
+     * @returns {Object} an object with api options
+     */
+    makeLayerConfig () {
+        const cfg = super.makeLayerConfig();
+        cfg.imageParameters = new this._apiRef.layer.ImageParameters();
+        cfg.imageParameters.format = 'png32';
+
+        return cfg;
+    }
+
+    /**
      * Return a proxy interface for a child layer
      *
      * @param {Integer} featureIdx    index of child entry (leaf or group)


### PR DESCRIPTION
## Description
<!-- Link to an issue (use #nnn for easy linking) or include a description -->

Supports https://github.com/fgpv-vpgf/fgpv-vpgf/issues/2528

Fixes problem in dynamic layer child opacity updates where value updates would erase the values of other children.

Adds ability to use layer format from layer config snippet. Default is now `png32` to give best support for child opacity

## Testing
<!-- Have you added unit tests for this code?  If not explain why. -->

No because it affects map layers.

## Documentation
<!-- Which areas of documentation have been changed: jsdoc, tutorials, samples, wiki -->

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [x] `gulp test` succeeds without warnings or errors
- [ ] release notes have been updated
- [x] all commit messages are descriptive and follow guidelines
- [x] PR targets the correct release version
- I will assign this PR to the primary reviewer

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/geoapi/279)
<!-- Reviewable:end -->
