### PR TITLE
Api 02 file layer fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "geoApi",
-  "version": "2.2.1-5",
+  "version": "2.2.1-6",
   "description": "",
   "main": "src/index.js",
   "dependencies": {

--- a/src/layer/layerRec/attribFC.js
+++ b/src/layer/layerRec/attribFC.js
@@ -47,7 +47,7 @@ class AttribFC extends basicFC.BasicFC {
      * @returns {Promise}         resolves with a layer attribute data object
      */
     getAttribs () {
-        const attribDownloaded = this.attribsLoaded();
+        const attribsDownloaded = this.attribsLoaded();
 
         const attribPromise = this._layerPackage.getAttribs();
 
@@ -55,8 +55,14 @@ class AttribFC extends basicFC.BasicFC {
             // only trigger the event the first time when the download was in progress.
             // after the attribs have been downloaded, if triggered again through API, since the attributes have
             // previously been downloaded, this event will not trigger in the viewer
-            if (!attribDownloaded) {
+            if (!attribsDownloaded) {
                 this._parent._attribsAdded(this._idx, attrib.features);
+
+                // for file layers, since attributes are local and we have promise initially,
+                // must set loadIsDone to true after promise resolved to ensure we trigger event once and only once
+                if (this._parent.isFileLayer()) {
+                    this._layerPackage.loadIsDone = true;
+                }
             }
         });
 


### PR DESCRIPTION
## Description
Supports https://github.com/fgpv-vpgf/fgpv-vpgf/issues/2507

Sets `loadIsDone` flag for file layer attributes when promise resolves.

## Testing
npm run test :white_check_mark:

## Documentation
In-line comments

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [ ] `gulp test` succeeds without warnings or errors
- [ ] release notes have been updated
- [ ] all commit messages are descriptive and follow guidelines
- [ ] PR targets the correct release version
- I will assign this PR to the primary reviewer

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/geoapi/282)
<!-- Reviewable:end -->
