### PR TITLE
Graphic zoom on graphic record

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "geoApi",
-  "version": "2.2.1-17",
+  "version": "2.2.1-18",
   "description": "",
   "main": "src/index.js",
   "dependencies": {

--- a/src/layer/layerRec/layerInterface.js
+++ b/src/layer/layerRec/layerInterface.js
@@ -106,7 +106,11 @@ class LayerInterface {
         this._source = newSource;
     }
 
-    convertToGraphicsLayer (layerRecord) {
+    // forReal indicates we actually want a graphics layer.
+    // other "convert" functions use method due to common commands,
+    // but they are not forReal. this flag lets us skip things that
+    // should ONLY be applied for real graphics layer
+    convertToGraphicsLayer (layerRecord, forReal = true) {
         this._source = layerRecord;
         this._isPlaceholder = false;
 
@@ -117,10 +121,14 @@ class LayerInterface {
 
         this.setVisibility = standardSetVisibility;
         this.setOpacity = standardSetOpacity;
+
+        if (forReal) {
+            this.zoomToGraphic = graphicZoomToGraphic;
+        }
     }
 
     convertToSingleLayer (layerRecord) {
-        this.convertToGraphicsLayer(layerRecord);
+        this.convertToGraphicsLayer(layerRecord, false);
 
         newProp(this, 'symbology', standardGetSymbology);
         newProp(this, 'state', standardGetState);
@@ -519,6 +527,14 @@ function featureZoomToGraphic(oid, map, offsetFraction) {
 
 function dynamicLeafZoomToGraphic(oid, map, offsetFraction) {
     /* jshint validthis: true */
+    return this._source.zoomToGraphic(oid, map, offsetFraction);
+}
+
+function graphicZoomToGraphic(oid, map, offsetFraction) {
+    /* jshint validthis: true */
+
+    // secret. its not really oid. its api id. see comments in graphicRecord.js.
+    // clean up when we get better design.
     return this._source.zoomToGraphic(oid, map, offsetFraction);
 }
 


### PR DESCRIPTION
## Description
<!-- Link to an issue (use #nnn for easy linking) or include a description -->

Apply a modified version of `zoomToGraphic` on the `GraphicRecord` class. This is a quick fix to support CIP demo. A more proper approach of adding an API zoom endpoint and cleaner code will be done later.

## Testing
<!-- Have you added unit tests for this code?  If not explain why. -->

Added some points and polygons, did some API zooms, tried some offsets.

Use geoApi `v2.2.1-18` to test locally.

API commands for testing

```js
const aPoint = new RZ.GEO.Point('factory', 'https://image.flaticon.com/icons/svg/17/17799.svg', [-78.4, 44.6]);
const mymap = RZ.mapInstances[0];
mymap.simpleLayer.addGeometry(aPoint);
mymap.simpleLayer._layerProxy.zoomToGraphic('factory', mymap._fgpMap, {x: 0, y: 0});
```

## Documentation
<!-- Which areas of documentation have been changed: jsdoc, tutorials, samples, wiki -->
Some nice comments

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [x] `gulp test` succeeds without warnings or errors
- [ ] release notes have been updated
- [x] all commit messages are descriptive and follow guidelines
- [x] PR targets the correct release version
- I will assign this PR to the primary reviewer

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/geoapi/290)
<!-- Reviewable:end -->
