### PR TITLE
fix(basemap): gallery initialization after fake layer removal

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "geoApi",
-  "version": "2.2.1-18",
+  "version": "2.2.1-20",
   "description": "",
   "main": "src/index.js",
   "dependencies": {


### PR DESCRIPTION
## Description
Initalize the basemap gallery after the fake GeoJSON layer has been removed as opposed to on `load` event.

## Testing
`npm run test`

## Documentation
None

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [x] `gulp test` succeeds without warnings or errors
- [ ] release notes have been updated
- [x] all commit messages are descriptive and follow guidelines
- [x] PR targets the correct release version
- I will assign this PR to the primary reviewer