### PR TITLE
North arrow specify point

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "geoApi",
-  "version": "2.4.0-3",
+  "version": "2.4.0-4",
   "description": "",
   "main": "src/index.js",
   "dependencies": {

--- a/src/map/esriMap.js
+++ b/src/map/esriMap.js
@@ -226,12 +226,15 @@ function esriMap(esriBundle, geoApi) {
          * Calculate north arrow bearing. Angle returned is to to rotate north arrow image.
          * http://www.movable-type.co.uk/scripts/latlong.html
          * @function getNorthArrowAngle
+         * @param {Object} opts options to apply to north arrow calculation
          * @returns {Number} map rotation angle (in degree)
          */
-        getNorthArrowAngle () {
-            // get center point in longitude and use bottom value for latitude
-            const pointB = geoApi.proj.localProjectPoint(this._map.extent.spatialReference, 'EPSG:4326',
-                    { x: (this._map.extent.xmin + this._map.extent.xmax) / 2, y: this._map.extent.ymin });
+        getNorthArrowAngle (opts) {
+            // get center point in longitude and use bottom value for latitude for default point
+            const bottomCenter = { x: (this._map.extent.xmin + this._map.extent.xmax) / 2, y: this._map.extent.ymin };
+            // get point if specified by caller else get default
+            const point = opts ? opts.point || bottomCenter : bottomCenter;
+            const pointB = geoApi.proj.localProjectPoint(this._map.extent.spatialReference, 'EPSG:4326', point);
 
             // north value (set longitude to be half of Canada extent (141° W, 52° W))
             const pointA = { x: -96, y: 90 };


### PR DESCRIPTION
## Description
<!-- Link to an issue (use #nnn for easy linking) or include a description -->
Allows the north arrow angle to be calculated from a specified point instead of only at the bottom center. 

## Testing
<!-- Have you added unit tests for this code?  If not explain why. -->
`npm run test`

## Documentation
<!-- Which areas of documentation have been changed: jsdoc, tutorials, samples, wiki -->
None

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [x] `gulp test` succeeds without warnings or errors
- [ ] release notes have been updated
- [x] all commit messages are descriptive and follow guidelines
- [x] PR targets the correct release version
- I will assign this PR to the primary reviewer

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/geoapi/298)
<!-- Reviewable:end -->
