### PR TITLE
Support basemap opacity per sublayer

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "geoApi",
-  "version": "2.4.0-6",
+  "version": "2.4.0-7",
   "description": "",
   "main": "src/index.js",
   "dependencies": {

--- a/src/map/basemap.js
+++ b/src/map/basemap.js
@@ -46,7 +46,7 @@ function initBasemaps(esriBundle, basemapsConfig, map) {
 function createBasemap(esriBundle, basemapConfig) {
     // create basemap, add to basemap gallery
     const layers = basemapConfig.layers.map(config =>
-        new esriBundle.BasemapLayer({ url: config.url, opacity: basemapConfig.opacity }));
+        new esriBundle.BasemapLayer({ url: config.url, opacity: config.opacity }));
 
     const basemap = new esriBundle.Basemap({
         id: basemapConfig.id,


### PR DESCRIPTION
## Description
<!-- Link to an issue (use #nnn for easy linking) or include a description -->

Supports https://github.com/fgpv-vpgf/fgpv-vpgf/issues/2463

Allows config to target the opacity of individual tiles in a basemap collection. Allows for fancy overlays.

## Testing
<!-- Have you added unit tests for this code?  If not explain why. -->

Tried out some modified configs. They looked lovely.

## Documentation
<!-- Which areas of documentation have been changed: jsdoc, tutorials, samples, wiki -->

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [x] `gulp test` succeeds without warnings or errors
- [ ] release notes have been updated
- [x] all commit messages are descriptive and follow guidelines
- [x] PR targets the correct release version
- I will assign this PR to the primary reviewer

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/geoapi/299)
<!-- Reviewable:end -->
