### PR TITLE
fix(map): catch shiftzoom errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "geoApi",
-  "version": "2.4.0-4",
+  "version": "2.4.0-6",
   "description": "",
   "main": "src/index.js",
   "dependencies": {


### PR DESCRIPTION
## Description
Catches zoom errors or otherwise they will prevent subsequent zooms.

Closes fgpv-vpgf/fgpv-vpgf#2730

## Testing
:eyes: 

## Documentation
<!-- Which areas of documentation have been changed: jsdoc, tutorials, samples, wiki -->

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [x] `gulp test` succeeds without warnings or errors
- [x] release notes have been updated
- [x] all commit messages are descriptive and follow guidelines
- [x] PR targets the correct release version
- I will assign this PR to the primary reviewer

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/geoapi/301)
<!-- Reviewable:end -->
