### PR TITLE
WFS race condition support

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "geoApi",
-  "version": "2.5.0-5",
+  "version": "2.5.0-7",
   "description": "",
   "main": "src/index.js",
   "dependencies": {

--- a/src/layer/layerRec/layerInterface.js
+++ b/src/layer/layerRec/layerInterface.js
@@ -23,7 +23,7 @@ class LayerInterface {
 
     get isPlaceholder () { return this._isPlaceholder; } // returns Boolean
 
-    // these expose ui controls available on the interface and indicate which ones are disabled
+    // the symbology for the layer
     get symbology () { return undefined; } // returns Array
 
     // can be group or node name

--- a/src/layer/layerRec/placeholderFC.js
+++ b/src/layer/layerRec/placeholderFC.js
@@ -48,6 +48,21 @@ class PlaceholderFC extends root.Root {
     // feature Record (feature layer) vs a dynamic Record (dynamic layer)
     get parentLayerType () { return this._parent.layerType; }
 
+    /**
+     * Indicates if the feature class is not visible at the given scale,
+     * and if so, if we need to zoom in to see it or zoom out. Placeholder is always in scale
+     *
+     * @function isOffScale
+     * @param {Integer}  mapScale the scale to test against
+     * @returns {Object} has boolean properties `offScale` and `zoomIn`
+     */
+    isOffScale (mapScale) {
+        return {
+            offScale: false,
+            zoomIn: false
+        };
+    }
+
 }
 
 module.exports = () => ({


### PR DESCRIPTION
## Description
<!-- Link to an issue (use #nnn for easy linking) or include a description -->

Supports https://github.com/fgpv-vpgf/fgpv-vpgf/issues/2859

Wires in new behavior for WFS layers that originate from the config.  Will block in a `loading` state and not generate an ESRI Feature Layer.  New public function to then pass in a premade ESRI Feature Layer after the fact, wire it in, then set layer to loaded.

## Testing
<!-- Have you added unit tests for this code?  If not explain why. -->

Tested against autopop legends, structured legends, and CCCS viewer.

## Documentation
<!-- Which areas of documentation have been changed: jsdoc, tutorials, samples, wiki -->

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [ ] `gulp test` succeeds without warnings or errors
- [ ] release notes have been updated
- [ ] all commit messages are descriptive and follow guidelines
- [ ] PR targets the correct release version
- I will assign this PR to the primary reviewer

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/geoapi/313)
<!-- Reviewable:end -->
