### PR TITLE
feat(WMS): allow getCapabilities to be turned off

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "geoApi",
-  "version": "2.5.0-7",
+  "version": "2.5.0-8",
   "description": "",
   "main": "src/index.js",
   "dependencies": {

--- a/src/index.js
+++ b/src/index.js
@@ -73,6 +73,7 @@ module.exports = function (esriLoaderUrl, window) {
         ['esri/layers/ImageParameters', 'ImageParameters'],
         ['esri/layers/LayerDrawingOptions', 'LayerDrawingOptions'],
         ['esri/layers/WMSLayer', 'WmsLayer'],
+        ['esri/layers/WMSLayerInfo', 'WMSLayerInfo'],
         ['esri/map', 'Map'],
         ['esri/request', 'esriRequest'],
         ['esri/SpatialReference', 'SpatialReference'],

--- a/src/layer.js
+++ b/src/layer.js
@@ -1283,6 +1283,7 @@ module.exports = function (esriBundle, geoApi) {
         validateFile,
         csvPeek,
         serviceType,
-        validateLatLong
+        validateLatLong,
+        WMSLayerInfo: esriBundle.WMSLayerInfo
     };
 };

--- a/src/layer/layerRec/wmsRecord.js
+++ b/src/layer/layerRec/wmsRecord.js
@@ -47,6 +47,14 @@ class WmsRecord extends layerRecord.LayerRecord {
             styles: styles
         };
 
+        if (this.config.suppressGetCapabilities) {
+            cfg.resourceInfo = {
+                extent: new this._apiRef.Map.Extent(-141, 41, -52, 83.5, {wkid: 4326}), // TODO make this a parameter post-demo
+                layerInfos: this.config.layerEntries
+                    .map(le => new this._apiRef.layer.WMSLayerInfo({name: le.id, title: le.name || ''}))
+            };
+        }
+
         return cfg;
     }
 


### PR DESCRIPTION
## Description
Avoids a getCapabilities call by providing a `resourceInfo` config parameter if the WMS ramp config has a property called `suppressGetCapabilities` and is set to `true`.

## Testing
![brain](https://user-images.githubusercontent.com/10187181/42892779-ac8bf208-8a80-11e8-966e-e2cac23b20b0.gif)

## Documentation
inline

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [ ] ~~`gulp test` succeeds without warnings or errors~~
- [ ] release notes have been updated
- [x] all commit messages are descriptive and follow guidelines
- [x] PR targets the correct release version
- I will assign this PR to the primary reviewer

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/geoapi/314)
<!-- Reviewable:end -->
