### PR TITLE
Support json wms identify

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "geoApi",
-  "version": "2.5.0-11",
+  "version": "2.5.0-12",
   "description": "",
   "main": "src/index.js",
   "dependencies": {

--- a/src/layer/layerRec/wmsRecord.js
+++ b/src/layer/layerRec/wmsRecord.js
@@ -134,8 +134,13 @@ class WmsRecord extends layerRecord.LayerRecord {
 
                 // TODO: check for French service
                 // check if a result is returned by the service. If not, do not add to the array of data
-                if (data.indexOf('Search returned no results') === -1 && data !== '') {
-                    identifyResult.data.push(data);
+                if (data) {
+                    if (typeof data !== 'string') {
+                        // likely json or an image
+                        identifyResult.data.push(data);
+                    } else if (data.indexOf('Search returned no results') === -1 && data !== '') {
+                        identifyResult.data.push(data);
+                    } 
                 }
 
                 // console.info(data);

--- a/src/layer/ogc.js
+++ b/src/layer/ogc.js
@@ -23,6 +23,13 @@ function getFeatureInfoBuilder(esriBundle) {
         const intX = parseInt(clickEvent.screenPoint.x);
         const intY = parseInt(clickEvent.screenPoint.y);
 
+        // result return type is text unless we have a fancy case
+        const customReturnType = {
+            "application/json": "json"
+        };
+
+        const returnType = customReturnType[mimeType] || "text";
+
         if (srList && srList.length > 1) {
             wkid = srList[0];
         } else if (esriMap.spatialReference.wkid) {
@@ -55,7 +62,7 @@ function getFeatureInfoBuilder(esriBundle) {
         return Promise.resolve(esriBundle.esriRequest({
             url: wmsLayer.url.split('?')[0],
             content: req,
-            handleAs: 'text'
+            handleAs: returnType
         }));
     };
 }


### PR DESCRIPTION
## Description
<!-- Link to an issue (use #nnn for easy linking) or include a description -->
Support for CCCS.  If identify request on WMS is of mime type json, fetch the result as json, not text.
Closes https://github.com/fgpv-vpgf/fgpv-vpgf/issues/2905

## Testing
<!-- Have you added unit tests for this code?  If not explain why. -->
Tested against CCCS layer with JSON mime type.
Tested against classic WMS with text results to ensure text still works

## Documentation
<!-- Which areas of documentation have been changed: jsdoc, tutorials, samples, wiki -->

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [ ] `gulp test` succeeds without warnings or errors
- [ ] release notes have been updated
- [ ] all commit messages are descriptive and follow guidelines
- [ ] PR targets the correct release version
- I will assign this PR to the primary reviewer

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/geoapi/317)
<!-- Reviewable:end -->
