### PR TITLE
fix(layerRecord): add outline to default points

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "geoApi",
-  "version": "2.5.0-14",
+  "version": "2.5.0-15",
   "description": "",
   "main": "src/index.js",
   "dependencies": {

--- a/src/defaultRenderers.json
+++ b/src/defaultRenderers.json
@@ -6,8 +6,22 @@
             "symbol": {
                 "type": "esriSMS",
                 "style": "esriSMSCircle",
-                "color": [67, 100, 255, 200],
-                "size": 7
+                "color": [
+                    67,
+                    100,
+                    255,
+                    200
+                ],
+                "size": 7,
+                "outline": {
+                    "color": [
+                        0,
+                        0,
+                        0,
+                        255
+                    ],
+                    "width": 1
+                }
             }
         }
     },
@@ -18,7 +32,12 @@
             "symbol": {
                 "type": "esriSLS",
                 "style": "esriSLSSolid",
-                "color": [90, 90, 90, 200],
+                "color": [
+                    90,
+                    90,
+                    90,
+                    200
+                ],
                 "width": 2
             }
         }
@@ -30,11 +49,21 @@
             "symbol": {
                 "type": "esriSFS",
                 "style": "esriSFSSolid",
-                "color": [76, 76, 125, 200],
+                "color": [
+                    76,
+                    76,
+                    125,
+                    200
+                ],
                 "outline": {
                     "type": "esriSLS",
                     "style": "esriSLSSolid",
-                    "color": [110, 110, 110, 255],
+                    "color": [
+                        110,
+                        110,
+                        110,
+                        255
+                    ],
                     "width": 1
                 }
             }
@@ -47,11 +76,21 @@
             "symbol": {
                 "type": "esriSFS",
                 "style": "esriSFSSolid",
-                "color": [255, 0, 0, 64],
+                "color": [
+                    255,
+                    0,
+                    0,
+                    64
+                ],
                 "outline": {
                     "type": "esriSLS",
                     "style": "esriSLSSolid",
-                    "color": [240, 128, 128, 255],
+                    "color": [
+                        240,
+                        128,
+                        128,
+                        255
+                    ],
                     "width": 1
                 }
             }


### PR DESCRIPTION
## Description
Creates black circle outlines for default points (helpful for WFS layers). `outline` added to `circlePoint`

## Testing
<!-- Have you added unit tests for this code?  If not explain why. -->
:eyes:

## Documentation
<!-- Which areas of documentation have been changed: jsdoc, tutorials, samples, wiki -->
n/a

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [ ] `gulp test` succeeds without warnings or errors
- [x] release notes have been updated
- [x] all commit messages are descriptive and follow guidelines
- [x] PR targets the correct release version
- I will assign this PR to the primary reviewer

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/geoapi/320)
<!-- Reviewable:end -->
