### PR TITLE
Support unencoded layer data

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "geoApi",
-  "version": "2.5.0-15",
+  "version": "2.5.0-16",
   "description": "",
   "main": "src/index.js",
   "dependencies": {

--- a/src/layer/layerRec/featureRecord.js
+++ b/src/layer/layerRec/featureRecord.js
@@ -192,7 +192,6 @@ class FeatureRecord extends attribRecord.AttribRecord {
 
         loadPromises.push(pLD, pFC, pLS);
         Promise.all(loadPromises).then(() => {
-            this.canAddToMap = true;
             this._stateChange(shared.states.LOADED);
         });
     }

--- a/src/layer/layerRec/layerRecord.js
+++ b/src/layer/layerRec/layerRecord.js
@@ -601,7 +601,6 @@ class LayerRecord extends root.Root {
         this._user = false;
         this._epsgLookup = epsgLookup;
         this.extent = config.extent; // if missing, will fill more values after layer loads
-        this.canAddToMap = true; // WFS HACK . fancy flag to prevent a pre-loading wfs from being added to map. neg
 
         // TODO verify we still use passthrough bindings.
         this._layerPassthroughBindings.forEach(bindingName =>
@@ -618,7 +617,6 @@ class LayerRecord extends root.Root {
             // funny case where we have to kind of pause everything
             // need this in layerRecord as it's constructor is executed before featureRecord's constructor
             this._state = shared.states.LOADING;
-            this.canAddToMap = false;
         } else if (esriLayer) {
             this.constructLayer = () => { throw new Error('Cannot construct pre-made layers'); };
             this._layer = esriLayer;

--- a/src/layer/ogc.js
+++ b/src/layer/ogc.js
@@ -25,10 +25,10 @@ function getFeatureInfoBuilder(esriBundle) {
 
         // result return type is text unless we have a fancy case
         const customReturnType = {
-            "application/json": "json"
+            'application/json': 'json'
         };
 
-        const returnType = customReturnType[mimeType] || "text";
+        const returnType = customReturnType[mimeType] || 'text';
 
         if (srList && srList.length > 1) {
             wkid = srList[0];


### PR DESCRIPTION
## Description
<!-- Link to an issue (use #nnn for easy linking) or include a description -->
When validating file / WFS layer data, now have the option to provide in a non-encoded format.

Also removes some hack properties from the WFS demo madness, and corrects some quotes.

Requirements driven from CCCS project

## Testing
<!-- Have you added unit tests for this code?  If not explain why. -->
`npm run test`


## Documentation
<!-- Which areas of documentation have been changed: jsdoc, tutorials, samples, wiki -->

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [ ] `gulp test` succeeds without warnings or errors
- [ ] release notes have been updated
- [ ] all commit messages are descriptive and follow guidelines
- [ ] PR targets the correct release version
- I will assign this PR to the primary reviewer

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/geoapi/321)
<!-- Reviewable:end -->
