### PR TITLE
fix(print): clone svgs in print map process

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "geoApi",
-  "version": "2.4.0-8",
+  "version": "2.5.0-16",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,45 +1,45 @@
 {
-  "name": "geoApi",
-  "version": "2.5.0-16",
-  "description": "",
-  "main": "src/index.js",
-  "dependencies": {
-    "babel-cli": "^6.24.1",
-    "babel-preset-env": "1.6.1",
-    "babel-preset-latest": "^6.24.1",
-    "babel-preset-stage-2": "^6.24.1",
-    "canvg-origin": "^1.0.0",
-    "csv2geojson": "5.0.2",
-    "dgeni": "^0.4.7",
-    "dgeni-packages": "^0.19.1",
-    "docdash": "https://github.com/alyec/docdash#master",
-    "jasmine": "^2.6.0",
-    "jquery": "^2.2.1",
-    "jsdoc": "^3.4.0",
-    "lodash": "^4.17.4",
-    "proj4": "^2.4.3",
-    "rcolor": "1.0.1",
-    "rgbcolor": "1.0.1",
-    "shpjs": "https://github.com/fgpv-vpgf/shapefile-js.git#v3.6.0",
-    "svg.js": "2.6.1",
-    "terraformer": "~1.0.8",
-    "terraformer-arcgis-parser": "~1.0.5",
-    "terraformer-proj4js": "https://github.com/RAMP-PCAR/terraformer-proj4js.git#v0.2.2",
-    "text-encoding": "0.6.4"
-  },
-  "scripts": {
-    "doc": "./node_modules/.bin/jsdoc -p -r -c .jsdoc.json -t node_modules/docdash -R README.md -d ./docbuild -u ./docs/content ./src",
-    "servedoc": "npm run doc && ./node_modules/.bin/http-server -p 6004 ./docbuild",
-    "test": "babel-node spec/support/specRunner.js"
-  },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/fgpv-vpgf/geoApi.git"
-  },
-  "author": "Government of Canada",
-  "license": "MIT",
-  "bugs": {
-    "url": "https://github.com/fgpv-vpgf/geoApi/issues"
-  },
-  "homepage": "https://fgpv-vpgf.github.io/geoApi"
+    "name": "geoApi",
+    "version": "2.5.0-17",
+    "description": "",
+    "main": "src/index.js",
+    "dependencies": {
+        "babel-cli": "^6.24.1",
+        "babel-preset-env": "1.6.1",
+        "babel-preset-latest": "^6.24.1",
+        "babel-preset-stage-2": "^6.24.1",
+        "canvg-origin": "^1.0.0",
+        "csv2geojson": "5.0.2",
+        "dgeni": "^0.4.7",
+        "dgeni-packages": "^0.19.1",
+        "docdash": "https://github.com/alyec/docdash#master",
+        "jasmine": "^2.6.0",
+        "jquery": "^2.2.1",
+        "jsdoc": "^3.4.0",
+        "lodash": "^4.17.4",
+        "proj4": "^2.4.3",
+        "rcolor": "1.0.1",
+        "rgbcolor": "1.0.1",
+        "shpjs": "https://github.com/fgpv-vpgf/shapefile-js.git#v3.6.0",
+        "svg.js": "2.6.1",
+        "terraformer": "~1.0.8",
+        "terraformer-arcgis-parser": "~1.0.5",
+        "terraformer-proj4js": "https://github.com/RAMP-PCAR/terraformer-proj4js.git#v0.2.2",
+        "text-encoding": "0.6.4"
+    },
+    "scripts": {
+        "doc": "./node_modules/.bin/jsdoc -p -r -c .jsdoc.json -t node_modules/docdash -R README.md -d ./docbuild -u ./docs/content ./src",
+        "servedoc": "npm run doc && ./node_modules/.bin/http-server -p 6004 ./docbuild",
+        "test": "babel-node spec/support/specRunner.js"
+    },
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/fgpv-vpgf/geoApi.git"
+    },
+    "author": "Government of Canada",
+    "license": "MIT",
+    "bugs": {
+        "url": "https://github.com/fgpv-vpgf/geoApi/issues"
+    },
+    "homepage": "https://fgpv-vpgf.github.io/geoApi"
 }

--- a/src/map/print.js
+++ b/src/map/print.js
@@ -143,9 +143,8 @@ function generateLocalCanvas(map, options = null, canvas = null) {
         Object.entries(XML_ATTRIBUTES).forEach(([key, value]) => svgNodeClone.setAttribute(key, value));
     }
 
-    let originalOptions;
     if (options) {
-        originalOptions = resizeSVGElement(svgNodeClone, options);
+        resizeSVGElement(svgNodeClone, options);
     }
 
     const generationPromise = new Promise((resolve, reject) => {
@@ -160,10 +159,6 @@ function generateLocalCanvas(map, options = null, canvas = null) {
                 ignoreAnimation: true,
                 ignoreMouse: true,
                 renderCallback: () => {
-                    if (options) {
-                        resizeSVGElement(svgNodeClone, originalOptions.originalSize, originalOptions.originalViewbox);
-                    }
-
                     resolve(canvas);
                 }
             });


### PR DESCRIPTION
## Description
<!-- Link to an issue (use #nnn for easy linking) or include a description -->
Print map was modifying layer SVGs and causing them to be offset when the map resized.
Most prominent was print map -> fullscreen pushing features away from their proper locations.

## Testing
<!-- Have you added unit tests for this code?  If not explain why. -->
index-samples 76 and 75

## Documentation
<!-- Which areas of documentation have been changed: jsdoc, tutorials, samples, wiki -->
in-line

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [ ] `gulp test` succeeds without warnings or errors
- [ ] release notes have been updated
- [ ] all commit messages are descriptive and follow guidelines
- [ ] PR targets the correct release version
- I will assign this PR to the primary reviewer

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/geoapi/322)
<!-- Reviewable:end -->
