### PR TITLE
fix(map): respect extent fit on init extent

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "geoApi",
-    "version": "2.5.0-24",
+    "version": "2.5.0-25",
     "description": "",
     "main": "src/index.js",
     "dependencies": {

--- a/src/map/esriMap.js
+++ b/src/map/esriMap.js
@@ -52,7 +52,11 @@ function esriMap(esriBundle, geoApi) {
                 Object.defineProperty(this, propName, descriptor);
             });
 
-            this._map = new esriBundle.Map(domNode, { extent: Map.getExtentFromJson(opts.extent), lods: opts.lods });
+            this._map = new esriBundle.Map(domNode, {
+                extent: Map.getExtentFromJson(opts.extent),
+                lods: opts.lods,
+                fitExtent: true
+            });
             if (opts.proxyUrl) {
                 this.proxy = opts.proxyUrl;
             }


### PR DESCRIPTION
## Description
<!-- Link to an issue (use #nnn for easy linking) or include a description -->
Supports https://github.com/fgpv-vpgf/fgpv-vpgf/issues/3023

Initial extent at map construction time was not being fitted to the screen. Adds the option to do that

## Testing
<!-- Have you added unit tests for this code?  If not explain why. -->

Tested on local build with an extent known to be naughty.  Proper tests can be vetted when the sibling PR on the viewer is queued up.

## Documentation
<!-- Which areas of documentation have been changed: jsdoc, tutorials, samples, wiki -->

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [x] `gulp test` succeeds without warnings or errors
- [ ] release notes have been updated
- [x] all commit messages are descriptive and follow guidelines
- [x] PR targets the correct release version
- I will assign this PR to the primary reviewer

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/geoapi/328)
<!-- Reviewable:end -->
