### PR TITLE
fix(dynamicRecord): identify results show with undefined clauses

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "geoApi",
-    "version": "2.5.0-22",
+    "version": "2.5.0-24",
     "description": "",
     "main": "src/index.js",
     "dependencies": {

--- a/src/layer/layerRec/dynamicRecord.js
+++ b/src/layer/layerRec/dynamicRecord.js
@@ -681,15 +681,16 @@ class DynamicRecord extends attribRecord.AttribRecord {
 
         opts.layerIds.forEach(leafIndex => {
             let childProxy = this.getChildProxy(leafIndex);
-
-            // track a list of valid symbologies so that identify doesn't return all symbologies in stack
-            if (this.definitionClause) {
-                childProxy.symbology.forEach(symbol => {
-                    if (this.definitionClause.includes(symbol.definitionClause)) {
-                        validSymbologies.push(symbol.svgcode);
-                    }
-                });
-            }
+            childProxy.symbology.forEach(symbol => {
+                //if there is a definition clause, filter out by definition clause
+                if (this.definitionClause && this.definitionClause.includes(symbol.definitionClause)) {
+                    validSymbologies.push(symbol.svgcode);
+                }
+                //otherwise all symbols are valid symbols
+                else if (this.definitionClause === undefined) {
+                    validSymbologies.push(symbol.svgcode);
+                }
+            });
             const identifyResult = new shared.IdentifyResult(childProxy);
             identifyResults[leafIndex] = identifyResult;
         });


### PR DESCRIPTION
## Description
<!-- Link to an issue (use #nnn for easy linking) or include a description -->
As per CGCC chat: identify did not work for child 0 of this layer: https://maps-cartes.dev.ec.gc.ca/arcgis/rest/services/CGCC/MapServer/0

## Testing
<!-- Have you added unit tests for this code?  If not explain why. -->
When PR'd on viewer repo test with child 0 of this layer:  https://maps-cartes.dev.ec.gc.ca/arcgis/rest/services/CGCC/MapServer/0

Also try identifying with other Dynamic layer symbology stacks (eg: `keys=NPRI_CO`, sample 46, etc)


## Documentation
<!-- Which areas of documentation have been changed: jsdoc, tutorials, samples, wiki -->
inline comments

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- ~[ ] `gulp test` succeeds without warnings or errors~
- ~[ ] release notes have been updated~
- [x] all commit messages are descriptive and follow guidelines
- [x] PR targets the correct release version
- I will assign this PR to the primary reviewer

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/geoapi/329)
<!-- Reviewable:end -->
