### PR TITLE
Use custom params in wms identify

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "geoApi",
-  "version": "2.5.0-29",
+  "version": "2.5.0-30",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "geoApi",
-    "version": "2.5.0-29",
+    "version": "2.5.0-30",
     "description": "",
     "main": "src/index.js",
     "dependencies": {

--- a/src/layer/ogc.js
+++ b/src/layer/ogc.js
@@ -57,6 +57,15 @@ function getFeatureInfoBuilder(esriBundle) {
             INFO_FORMAT: mimeType
         };
 
+        // apply any custom parameters (ignore styles for the moment)
+        if (wmsLayer.customLayerParameters) {
+            Object.keys(wmsLayer.customLayerParameters).forEach(key => {
+                if (key.toLowerCase() !== 'styles') {
+                    settings[key] = wmsLayer.customLayerParameters[key];
+                }
+            });
+        }
+
         Object.keys(settings).forEach(key => req[key] = settings[key]);
 
         return Promise.resolve(esriBundle.esriRequest({


### PR DESCRIPTION
## Description
<!-- Link to an issue (use #nnn for easy linking) or include a description -->
Includes custom parameters on WMS identify calls
Supports https://github.com/fgpv-vpgf/fgpv-vpgf/issues/3096

## Testing
<!-- Have you added unit tests for this code?  If not explain why. -->
Tested showing & clicking regular WMS layers in standard app.
Tested the build in CCP viewer with time enabled layer, ensured the time was applied to the identify request and correct value was displayed in the viewer.

## Documentation
<!-- Which areas of documentation have been changed: jsdoc, tutorials, samples, wiki -->

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [ ] `gulp test` succeeds without warnings or errors
- [ ] release notes have been updated
- [ ] all commit messages are descriptive and follow guidelines
- [ ] PR targets the correct release version
- I will assign this PR to the primary reviewer

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/geoapi/332)
<!-- Reviewable:end -->
