### PR TITLE
fix(safari): revert ns1 svg link fix for identify

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "geoApi",
-  "version": "2.5.0-27",
+  "version": "2.5.0-29",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "geoApi",
-    "version": "2.5.0-27",
+    "version": "2.5.0-29",
     "description": "",
     "main": "src/index.js",
     "dependencies": {

--- a/src/layer/layerRec/dynamicRecord.js
+++ b/src/layer/layerRec/dynamicRecord.js
@@ -731,7 +731,7 @@ class DynamicRecord extends attribRecord.AttribRecord {
                             const objId = unAliasAtt[lData.oidField];
                             const objIdStr = objId.toString();
 
-                            // TODO traditionally, we did not pass fields into attributesToDetails as data was
+                            // TODO: traditionally, we did not pass fields into attributesToDetails as data was
                             //      already aliased from the server. now, since we are extracting field type as
                             //      well, this means things like date formatting might not be applied to
                             //      identify results. examine the impact of providing the fields parameter
@@ -739,7 +739,8 @@ class DynamicRecord extends attribRecord.AttribRecord {
                             let svg = this._apiRef.symbology.getGraphicIcon(unAliasAtt, lData.renderer);
 
                             //if the current svg is a valid symbology to be identified, push its data into identifyResult
-                            if (validSymbologies.indexOf(svg) !== -1) {
+                            // TODO: replace Safari only `ns1:href` attributes with regular links before trying to match against the results
+                            if (validSymbologies.indexOf(svg.replace(/ns1:href/gi, 'xlink:href')) !== -1) {
                                 identifyResult.data.push({
                                     name: this.getFeatureName(ele.layerId, objIdStr, unAliasAtt),
                                     data: this.attributesToDetails(ele.feature.attributes, lData.fields),


### PR DESCRIPTION
Undo replacement of  `xlink:href` with `ns1:href` for Safari browsers before comparing identify result svg icons.

Closes fgpv-vpgf/fgpv-vpgf#3102

## Description
<!-- Link to an issue (use #nnn for easy linking) or include a description -->

## Testing
<!-- Have you added unit tests for this code?  If not explain why. -->

## Documentation
<!-- Which areas of documentation have been changed: jsdoc, tutorials, samples, wiki -->

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [ ] `gulp test` succeeds without warnings or errors
- [ ] release notes have been updated
- [ ] all commit messages are descriptive and follow guidelines
- [ ] PR targets the correct release version
- I will assign this PR to the primary reviewer

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/geoapi/333)
<!-- Reviewable:end -->
