### PR TITLE
More flexible filters

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "geoApi",
-  "version": "3.0.0-3",
+  "version": "3.0.0-4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "geoApi",
-    "version": "3.0.0-3",
+    "version": "3.0.0-4",
     "description": "",
     "main": "src/index.js",
     "dependencies": {

--- a/src/layer/layerRec/attribRecord.js
+++ b/src/layer/layerRec/attribRecord.js
@@ -136,9 +136,10 @@ class AttribRecord extends layerRecord.LayerRecord {
      * Applies the current filter settings to the physical map layer.
      *
      * @function applyFilterToLayer
+     * @param {Array} [exclusions] list of any filters to exclude from the result. omission includes all keys
      */
-    applyFilterToLayer () {
-        this._featClasses[this._defaultFC].applyFilterToLayer();
+    applyFilterToLayer (exclusions = []) {
+        this._featClasses[this._defaultFC].applyFilterToLayer(exclusions);
     }
 
     /**

--- a/src/layer/layerRec/basicFC.js
+++ b/src/layer/layerRec/basicFC.js
@@ -172,9 +172,6 @@ class BasicFC extends placeholderFC.PlaceholderFC {
         throw new Error('Cannot get OIDs for non-attribute layers');
     }
 
-    getNonGridFilterOIDs () {
-        throw new Error('Cannot get OIDs for non-attribute layers');
-    }
 }
 
 module.exports = () => ({

--- a/src/layer/layerRec/dynamicFC.js
+++ b/src/layer/layerRec/dynamicFC.js
@@ -172,11 +172,12 @@ class DynamicFC extends attribFC.AttribFC {
      * Applies the current filter settings to the physical map layer.
      *
      * @function applyFilterToLayer
+     * @param {Array} [exclusions] list of any filters to exclude from the result. omission includes all keys
      */
-    applyFilterToLayer () {
+    applyFilterToLayer (exclusions = []) {
         // TODO do we need a check incase this FC is targeting a RasterLayer?
         //      i think as is the UI will turn off anything that would call this function.
-        const sql = this.filter.getCombinedSql();
+        const sql = this.filter.getCombinedSql(exclusions);
         this.setDefinitionQuery(sql);
     }
 

--- a/src/layer/layerRec/dynamicRecord.js
+++ b/src/layer/layerRec/dynamicRecord.js
@@ -576,10 +576,11 @@ class DynamicRecord extends attribRecord.AttribRecord {
      * Applies the current filter settings to the physical map layer.
      *
      * @function applyFilterToLayer
-     * @param {String}  childIndex      index of the child layer to target
+     * @param {String}  childIndex  index of the child layer to target
+     * @param {Array} [exclusions]  list of any filters to not apply. omission includes all filters
      */
-    applyFilterToLayer (childIndex) {
-        this._featClasses[childIndex].applyFilterToLayer();
+    applyFilterToLayer (childIndex, exclusions = []) {
+        this._featClasses[childIndex].applyFilterToLayer(exclusions);
     }
 
     /**

--- a/src/layer/layerRec/filter.js
+++ b/src/layer/layerRec/filter.js
@@ -12,7 +12,29 @@ class Filter {
     constructor (parent) {
         this._parent = parent;
 
-        this.clearAll();
+        // dictionaries of potential values
+        this._sql = {};
+        this._cache = {};
+    }
+
+    // exposes enumeration of core types to the client
+    get coreFilterTypes () { return shared.filterType; }
+
+    /**
+     * Returns list of filters that have active filters
+     *
+     * @method sqlActiveFilters
+     * @param {Array} [exclusions] list of any filters to exclude from the result. omission includes all filters
+     * @returns {Array} list of filters with active filter sql
+     */
+    sqlActiveFilters (exclusions = []) {
+        const s = this._sql;
+        const rawActive = Object.keys(s).filter(k => s[k]);
+        if (exclusions.length === 0) {
+            return rawActive;
+        } else {
+            return rawActive.filter(k => exclusions.indexOf(k) === -1);
+        }
     }
 
     /**
@@ -22,61 +44,43 @@ class Filter {
      * @returns {Boolean} indicates if any filters are active
      */
     isActive () {
-        return !!(this._symbolSql || this._apiSql || this._gridSql);
+        return this.sqlActiveFilters().length > 0;
     }
 
     /**
-     * Returns a SQL WHERE condition that is combination of any symbol and api filter statements that are active
-     *
-     * @method getCombinedNonGridSql
-     * @returns {String} combination of any active symbol and/or api filter statements
-     */
-    getCombinedNonGridSql () {
-        // puts all active layer-based sql statements into a single statement, ANDed
-        if (this._symbolSql && this._apiSql) {
-            return `${this._symbolSql} AND ${this._apiSql}`;
-        } else {
-            return this._symbolSql || this._apiSql;
-        }
-    }
-
-    /**
-     * Returns a SQL WHERE condition that is combination of any active filters.
+     * Returns a SQL WHERE condition that is combination of active filters.
      *
      * @method getCombinedSql
-     * @returns {String} combination of any active symbol, api, and grid filter statements
+     * @param {Array} [exclusions] list of any filters to exclude from the result. omission includes all filters
+     * @returns {String} all non-excluded sql statements connected with AND operators.
      */
-    getCombinedSql () {
-        // puts all active sql statements into a single statement, ANDed
-        const cSql = this.getCombinedNonGridSql();
+    getCombinedSql (exclusions = []) {
+        // list of active, non-excluded filters
+        const keys = this.sqlActiveFilters(exclusions);
 
-        if (cSql && this._gridSql) {
-            return `${cSql} AND ${this._gridSql}`;
+        const l = keys.length;
+        if (l === 0) {
+            return '';
+        } else if (l === 1) {
+            // no need for fancy brackets
+            return this._sql[keys[0]];
         } else {
-            return cSql || this._gridSql;
+            // wrap each nugget in bracket, connect with AND
+            return keys.map(k => `(${this._sql[k]})`).join(' AND ');
         }
-    }
-
-    /**
-     * Tells what object ids are currently passing the layer's filters, but omits any influence from grid filters.
-     *
-     * @method getNonGridFilterOIDs
-     * @param {Extent} [extent] if provided, the result list will only include features intersecting the extent
-     * @returns {Promise} resolves with array of valid OIDs that layer is filtering (excluding grid filters). resolves with undefined if there is no filters being used
-     */
-    getNonGridFilterOIDs (extent) {
-        return this._parent.getNonGridFilterOIDs(extent);
     }
 
     /**
      * Tells what object ids are currently passing the layer's filters.
      *
      * @method getFilterOIDs
+     * @param {Array} [exclusions] list of any filters to exclude from the result. omission includes all filters
      * @param {Extent} [extent] if provided, the result list will only include features intersecting the extent
      * @returns {Promise} resolves with array of valid OIDs that layer is filtering. resolves with undefined if there is no filters being used
      */
-    getFilterOIDs (extent) {
-        return this._parent.getFilterOIDs(extent);
+    getFilterOIDs (exclusions = [], extent) {
+        // TODO perhaps key-mapping here? figure out SQL here? meh
+        return this._parent.getFilterOIDs(exclusions, extent);
     }
 
     /**
@@ -105,52 +109,31 @@ class Filter {
     }
 
     /**
-     * Registers a new symbol filter clause and triggers filter change events.
+     * Updates a SQL filter clause and triggers filter change events.
      *
-     * @method setSymbolSql
+     * @method setSql
+     * @param {String} filterType name of the filter to update
      * @param {String} whereClause clause defining the active filters on symbols. Use '' for no filter. Use '1=2' for everything filtered.
      */
-    setSymbolSql (whereClause) {
-        this._symbolSql = whereClause;
+    setSql (filterType, whereClause) {
+        this._sql[filterType] = whereClause;
 
-        // invalidate caches
-        this.clearAllCaches();
+        // invalidate affected caches
+        this.clearCacheSet(filterType);
 
         // tell the world
-        this.eventRaiser(shared.filterType.SYMBOL);
+        this.eventRaiser(filterType);
     }
 
     /**
-     * Registers a new grid filter clause and triggers filter change events.
+     * Returns current SQL for a fitler type
      *
-     * @method setGridSql
-     * @param {String} whereClause clause defining the active filters on the grid. Use '' for no filter. Use '1=2' for everything filtered.
+     * @method getSql
+     * @param {String} filterType key string indicating what filter the sql belongs to
+     * @returns {String} the SQL, if any, that matches the filter type
      */
-    setGridSql (whereClause) {
-        this._gridSql = whereClause;
-
-        // clear caches that care about grid state.
-        this._layerOID = undefined;
-        this._layerExtentOID = undefined;
-
-        // tell the world
-        this.eventRaiser(shared.filterType.GRID);
-    }
-
-    /**
-     * Registers a new API filter clause and triggers filter change events.
-     *
-     * @method setApiSql
-     * @param {String} whereClause clause defining the active filters from the API. Use '' for no filter. Use '1=2' for everything filtered.
-     */
-    setApiSql (whereClause) {
-        this._apiSql = whereClause;
-
-        // invalidate caches
-        this.clearAllCaches();
-
-        // tell the world
-        this.eventRaiser(shared.filterType.API);
+    getSql (filterType) {
+        return this._sql[filterType] || '';
     }
 
     /**
@@ -170,44 +153,63 @@ class Filter {
             this._extent = extent;
 
             // clear caches that care about extent.
-            this._layerExtentOID = undefined;
-            this._layerNoGridExtentOID = undefined;
+            this.clearCacheSet(shared.filterType.EXTENT);
+
+            // We don't raise an event here. EXTENT event is a map-level thing, so a layer should not be raising it
+            // (we'd have each layer shooting off an event every pan if we did)
         }
-        
     }
 
     /**
-     * Returns cache property depending on the situation we are in.
-     * Values should align to properties of this class
+     * Returns cache key depending on the situation we are in.
      *
      * @method getCacheKey
-     * @param {Boolean} includeGridFilter if the cache includes grid based filters
+     * @private
+     * @param {Array} sqlFilters list of filters influencing this cache
      * @param {Boolean} includeExtent if the cache includes extent based filters
      * @returns {String} the cache key to use
      */
-    getCacheKey (includeGridFilter, includeExtent) {
-        const key = `${includeGridFilter ? 'Y' : 'N'}${includeExtent ? 'Y' : 'N'}`;
-        const resultMap = {
-            YY: '_layerExtentOID',
-            YN: '_layerOID',
-            NY: '_layerNoGridExtentOID',
-            NN: '_layerNoGridOID'
-        };
-
-        return resultMap[key];
+    getCacheKey (sqlFilters, includeExtent) {
+        const sqlKey = sqlFilters.sort().join('$');
+        return `_cache$${sqlKey}${includeExtent ? '$' + shared.filterType.EXTENT : ''}$`;
     }
 
     /**
-     * Resets all internal filter settings to have no filter applied. Does not trigger filter change events.
+     * Returns cache for a specific filtering scenario.
      *
-     * @method clearAll
+     * @method getCache
+     * @private
+     * @param {Array} sqlFilters list of filters influencing this cache
+     * @param {Boolean} includeExtent if the cache includes extent based filters
+     * @returns {Promise} resolves in a filter result appropriate for the parameters. returns nothing if no cache exists.
      */
-    clearAll () {
-        this._symbolSql = ''; // holds any symbol-filter sql string. '' means no filter active
-        this._apiSql = '';  // holds any api-defined sql string. '' means no filter active
-        this._gridSql = ''; // holds any grid sql string. '' means no filter active
-        this._extent = undefined; 
-        this.clearAllCaches();
+    getCache (sqlFilters, includeExtent) {
+        const key = this.getCacheKey(sqlFilters, includeExtent);
+        return this._cache[key];
+    }
+
+    /**
+     * Sets a filter query in a cache, so repeated identical requests will only hit the server once
+     *
+     * @method setCache
+     * @param {Promise} queryPromise the query we want to cache
+     * @param {Array} sqlFilters list of filters influencing this cache
+     * @param {Boolean} includeExtent if the cache includes extent based filters
+     */
+    setCache (queryPromise, sqlFilters, includeExtent) {
+        const key = this.getCacheKey(sqlFilters, includeExtent);
+        this._cache[key] = queryPromise;
+    }
+
+    /**
+     * Returns list of cache keys that have caches
+     *
+     * @method cacheActiveKeys
+     * @returns {Array} list of keys with active caches
+     */
+    cacheActiveKeys () {
+        const c = this._cache;
+        return Object.keys(c).filter(k => c[k]);
     }
 
     /**
@@ -216,12 +218,36 @@ class Filter {
      * @method clearAllCaches
      */
     clearAllCaches () {
-        this._layerOID = undefined; // promise.  resolves with list of OIDs that pass any SQL filters that are active
-        this._layerExtentOID = undefined; // promise.  resolves with list of OIDs that pass any SQL filters AND extent filters that are active
-        this._layerNoGridOID = undefined; // promise.  resolves with list of OIDs that pass any SQL filters that are active except for grid filters
-        this._layerNoGridExtentOID = undefined; // promise.  resolves with list of OIDs that pass any SQL filters (except for grid filters) AND extent filters that are active
+        // lol
+        this._cache = {};
     }
 
+    /**
+     * Resets all internal caches related to a filter.
+     *
+     * @method clearCacheSet
+     * @param {String} filterName filter that has changed and needs its caches wiped
+     */
+    clearCacheSet (filterName) {
+        // the keys are wrapped in $ chars to avoid matching similarly named filter keys.
+        // e.g. 'plugin' would also match 'plugin1' in an indexOf call, but '$plugin$' won't match '$plugin1$'
+        this.cacheActiveKeys().forEach(c => {
+            if (c.indexOf(`$${filterName}$`) > -1) {
+                this._cache[c] = undefined;
+            }
+        });
+    }
+
+    /**
+     * Resets all internal filter settings to have no filter applied. Does not trigger filter change events.
+     *
+     * @method clearAll
+     */
+    clearAll () {
+        this._sql = {};
+        this._extent = undefined; 
+        this.clearAllCaches();
+    }
 }
 
 module.exports = () => ({

--- a/src/layer/layerRec/shared.js
+++ b/src/layer/layerRec/shared.js
@@ -32,9 +32,10 @@ const dataSources = {
     FILE: 'file'
 }
 
+// these are "officially supported" types.  our filters can take other names (e.g. a plugin wants to name its own filter)
 const filterType = {
     SYMBOL: 'symbol',
-    API: 'api',
+    API: 'api', // this would be a default api key. e.g. if someone just does an API filter set with no key parameter, it would use this.
     GRID: 'grid',
     EXTENT: 'extent'
 }


### PR DESCRIPTION
## Description
<!-- Link to an issue (use #nnn for easy linking) or include a description -->
A refactor to remove specific-case function names (like `getNonGridOIDs` and `setSymbolSql`).
We can now take on any number of sql-based filters, allowing new plugins to have their own filter sets.
Added ability to exclude specific filters from key functions to.   E.g. if grid wants list of things a layer is filtering, it would exclude any grid-based filters.

Most changes are just affecting the internals of the filter object.

## Testing
<!-- Have you added unit tests for this code?  If not explain why. -->

Tested in local build.

## Documentation
<!-- Which areas of documentation have been changed: jsdoc, tutorials, samples, wiki -->

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [ ] `gulp test` succeeds without warnings or errors
- [ ] release notes have been updated
- [ ] all commit messages are descriptive and follow guidelines
- [ ] PR targets the correct release version
- [ ] has been tested in IE
- [ ] orignal issue has been reviewed & updated to reflect the PR content
- I will assign this PR to the primary reviewer

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/geoapi/337)
<!-- Reviewable:end -->
