### PR TITLE
Aql like operator respects start and end of string

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "geoApi",
-  "version": "3.0.0-11",
+  "version": "3.0.0-12",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "geoApi",
-    "version": "3.0.0-11",
+    "version": "3.0.0-12",
     "description": "",
     "main": "src/index.js",
     "dependencies": {

--- a/src/query.js
+++ b/src/query.js
@@ -328,8 +328,8 @@ class AqlLike extends AqlDiatomic {
         // TODO basic wildcard search for now. may need to handle escaping special characters
         //      can steal codes from https://stackoverflow.com/questions/1314045/emulating-sql-like-in-javascript
 
-        // convert % to *
-        pattern = pattern.replace(/%/g, '.*');
+        // convert % to *, and make pattern respect start and end of the string
+        pattern = `^${pattern.replace(/%/g, '.*')}$`;
 
         const result = RegExp(pattern).test(attVal);
         return this.hasNot ? !result : result;


### PR DESCRIPTION
## Description
<!-- Link to an issue (use #nnn for easy linking) or include a description -->
Closes https://github.com/fgpv-vpgf/fgpv-vpgf/issues/3430

Adds start and end of line restrictions to the AQL query engine for the `LIKE` operator, which affects file & WFS layers.

so now filter string `LIKE '101%'`
will match `1010203`
but not match `2010103`



## Testing
<!-- Have you added unit tests for this code?  If not explain why. -->

Tested using layers, both with lazyFilter enabled and disabled.
Proper tests can be done on the corresponding viewer PR, which will let you run ramp using this fix

## Documentation
<!-- Which areas of documentation have been changed: jsdoc, tutorials, samples, wiki -->

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [ ] `gulp test` succeeds without warnings or errors
- [ ] release notes have been updated
- [x] all commit messages are descriptive and follow guidelines
- [x] PR targets the correct release version
- [x] has been tested in IE
- [x] orignal issue has been reviewed & updated to reflect the PR content
- I will assign this PR to the primary reviewer

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/geoapi/345)
<!-- Reviewable:end -->
