### PR TITLE
Dynamic identify no result flag

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "geoApi",
-  "version": "3.0.0-12",
+  "version": "3.0.0-13",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "geoApi",
-    "version": "3.0.0-12",
+    "version": "3.0.0-13",
     "description": "",
     "main": "src/index.js",
     "dependencies": {

--- a/src/layer/layerRec/dynamicRecord.js
+++ b/src/layer/layerRec/dynamicRecord.js
@@ -749,7 +749,7 @@ class DynamicRecord extends attribRecord.AttribRecord {
 
                 // set the rest of the entries to loading false
                 identifyResults.forEach(identifyResult => {
-                    if (hitIndexes.indexOf(identifyResult.requester.featureIdx) === -1) {
+                    if (hitIndexes.indexOf(identifyResult.requester.proxy.itemIndex) === -1) {
                         identifyResult.isLoading = false;
                     }
                 });


### PR DESCRIPTION
## Description
<!-- Link to an issue (use #nnn for easy linking) or include a description -->
Supports fix for https://github.com/fgpv-vpgf/fgpv-vpgf/issues/3441

Logic to mark dynamic layers with no results was referencing non-existing properties.


## Testing
<!-- Have you added unit tests for this code?  If not explain why. -->

Tested against application (Sample 6)

## Documentation
<!-- Which areas of documentation have been changed: jsdoc, tutorials, samples, wiki -->

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [ ] `gulp test` succeeds without warnings or errors
- [ ] release notes have been updated
- [x] all commit messages are descriptive and follow guidelines
- [x] PR targets the correct release version
- [x] has been tested in IE
- [x] orignal issue has been reviewed & updated to reflect the PR content
- I will assign this PR to the primary reviewer

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/geoapi/346)
<!-- Reviewable:end -->
