### PR TITLE
Track initial load internally

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "geoApi",
-  "version": "3.1.0-4",
+  "version": "3.1.0-5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "geoApi",
-    "version": "3.1.0-4",
+    "version": "3.1.0-5",
     "description": "",
     "main": "src/index.js",
     "dependencies": {

--- a/src/layer/layerRec/featureRecord.js
+++ b/src/layer/layerRec/featureRecord.js
@@ -438,23 +438,6 @@ class FeatureRecord extends attribRecord.AttribRecord {
         this._layer.setDefinitionExpression(query);
     }
 
-    /**
-     * Hot swaps the core underlying layer of this record.
-     * THIS IS VERY VERY BAD.
-     * Doing this as a workaround to our fundamental WFS loading problem.
-     *
-     * @function updateWfsSource
-     * @param {Object} esriLayer an esri layer. specifically a FeatureLayer that's been pre-created from GeoJSON source
-     */
-    updateWfsSource (esriLayer) {
-        this._layer = esriLayer;
-        this.bindEvents(this._layer);
-        this._snapshot = true; // possibly redundant
-
-        // do the loading activites.  will trigger the loaded event.
-        this.onLoad();
-    }
-
 }
 
 module.exports = () => ({

--- a/src/layer/layerRec/wmsRecord.js
+++ b/src/layer/layerRec/wmsRecord.js
@@ -27,6 +27,9 @@ class WmsRecord extends layerRecord.LayerRecord {
         this._defaultFC = '0';
         this._featClasses['0'] = new placeholderFC.PlaceholderFC(this, this.name);
 
+        if (config.suppressGetCapabilities) {
+            this.onLoad();
+        }
     }
 
     get layerType () { return shared.clientLayerType.OGC_WMS; }


### PR DESCRIPTION
## Description
<!-- Link to an issue (use #nnn for easy linking) or include a description -->
Implements https://github.com/fgpv-vpgf/fgpv-vpgf/issues/3639

Moves tracking of "first load" to inside geoApi. Exposes new property on layer records `initLoadDone`.

Removes some legacy code from CCP WFS demo panic.

## Testing
<!-- Have you added unit tests for this code?  If not explain why. -->
Tested against

- ArcGIS Server layers
- ArcGIS Server layer initialized to invisible
- File based layers
- WFS Layers
- WMS Layers with baked capabilities

Ensured loading indicators on map and legend behaved as expected, and nothing weird was up.

Real testing available on viewer PR

## Documentation
<!-- Which areas of documentation have been changed: jsdoc, tutorials, samples, wiki -->

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [x] `gulp test` succeeds without warnings or errors
- [ ] release notes have been updated
- [x] all commit messages are descriptive and follow guidelines
- [x] PR targets the correct release version
- [ ] has been tested in IE
- [x] orignal issue has been reviewed & updated to reflect the PR content
- I will assign this PR to the primary reviewer

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/geoapi/354)
<!-- Reviewable:end -->
