### PR TITLE
Smart feature identify

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "geoApi",
-  "version": "3.1.0-8",
+  "version": "3.1.0-9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "geoApi",
-    "version": "3.1.0-8",
+    "version": "3.1.0-9",
     "description": "",
     "main": "src/index.js",
     "dependencies": {


### PR DESCRIPTION
## Description
<!-- Link to an issue (use #nnn for easy linking) or include a description -->

Closes https://github.com/fgpv-vpgf/fgpv-vpgf/issues/3292

If attributes of a feature layer have not been downloaded, no longer download them all when a map click / identify happens. Instead use the fast-lookup pipeline that hovertips use.

## Testing
<!-- Have you added unit tests for this code?  If not explain why. -->

Will be testable in the viewer PR.
Tests include

- ArcGIS Server Feature Layer
  - Clicking points before table has been opened. Verifying on network that only pings for clicked features are happening (no bulk downloads).
  - Clicking points after table has been opened. Verifying on network that no pings or bulk downloads happen. All lookups should be from local cache.
  - Clicking clusters of points that give multiple identify results
  - Clicking on overlapping layers where both layers give identify results
- File layer
  - Things act as always, both before and after table opens, stacked or unstacked results.

## Documentation
<!-- Which areas of documentation have been changed: jsdoc, tutorials, samples, wiki -->

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [ ] `gulp test` succeeds without warnings or errors
- [x] release notes have been updated
- [x] all commit messages are descriptive and follow guidelines
- [x] PR targets the correct release version
- [ ] has been tested in IE
- [x] orignal issue has been reviewed & updated to reflect the PR content
- I will assign this PR to the primary reviewer

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/geoapi/355)
<!-- Reviewable:end -->
