### PR TITLE
fix(attrib): fix lat/long map filtering

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "geoApi",
-  "version": "3.1.0-6",
+  "version": "3.1.0-8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "geoApi",
-    "version": "3.1.0-6",
+    "version": "3.1.0-8",
     "description": "",
     "main": "src/index.js",
     "dependencies": {

--- a/src/layer.js
+++ b/src/layer.js
@@ -963,8 +963,8 @@ function makeGeoJsonLayerBuilder(esriBundle, geoApi) {
                 {
                     name: 'OBJECTID',
                     type: 'esriFieldTypeOID',
-                },
-            ],
+                }
+            ]
         };
 
         // ensure our features have ids
@@ -1015,6 +1015,22 @@ function makeGeoJsonLayerBuilder(esriBundle, geoApi) {
         // look up projection definitions if they don't already exist and we have enough info
         const srcLookup = geoApi.proj.checkProj(srcProj, opts.epsgLookup);
         const destLookup =  geoApi.proj.checkProj(destProj, opts.epsgLookup);
+
+        // change latitude and longitude fields from esriFieldTypeString -> esriFieldTypeDouble if they exist
+        if (opts) {
+            if (opts.latfield) {
+                const latField = layerDefinition.fields.find(field => field.name === opts.latfield);
+                if (latField) {
+                    latField.type = 'esriFieldTypeDouble';
+                }
+            }
+            if (opts.lonfield) {
+                const longField = layerDefinition.fields.find(field => field.name === opts.lonfield);
+                if (longField) {
+                    longField.type = 'esriFieldTypeDouble';
+                }
+            }
+        }
 
         // make the layer
         const buildLayer = () => {


### PR DESCRIPTION
## Description
Closes fgpv-vpgf/fgpv-vpgf#3689 and fgpv-vpgf/fgpv-vpgf#3694

Convert LAT/LONG fields into `esriFieldTypeDouble` to be filtered and treated as numbers in plugins

## Testing
Later in the viewer PR

## Documentation
<!-- Which areas of documentation have been changed: jsdoc, tutorials, samples, wiki -->

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [ ] `gulp test` succeeds without warnings or errors
- [ ] release notes have been updated
- [x] all commit messages are descriptive and follow guidelines
- [x] PR targets the correct release version
- [ ] has been tested in IE
- [x] orignal issue has been reviewed & updated to reflect the PR content
- I will assign this PR to the primary reviewer

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/geoapi/356)
<!-- Reviewable:end -->
