### PR TITLE
feat(query): add support for Prefix for sqlToAql

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "geoApi",
-  "version": "3.1.0-9",
+  "version": "3.1.0-10",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "geoApi",
-    "version": "3.1.0-9",
+    "version": "3.1.0-10",
     "description": "",
     "main": "src/index.js",
     "dependencies": {


### PR DESCRIPTION
## Description
Closes https://github.com/fgpv-vpgf/fgpv-vpgf/issues/3699

When negative number filters are applied to map, there is no effect because there is no support for `Prefix` types such as `-` and `+`. Added this to `typeReactor` in `sqlNodeToAqlNode` to allow negative number filters to be applied to map. 

## Testing
Later in viewer 

## Documentation
<!-- Which areas of documentation have been changed: jsdoc, tutorials, samples, wiki -->

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [ ] `gulp test` succeeds without warnings or errors
- [ ] release notes have been updated
- [x] all commit messages are descriptive and follow guidelines
- [x] PR targets the correct release version
- [ ] has been tested in IE
- [x] orignal issue has been reviewed & updated to reflect the PR content
- I will assign this PR to the primary reviewer

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/geoapi/357)
<!-- Reviewable:end -->
